### PR TITLE
Add Sentry io.Writer for integration with standard logging platform

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,21 @@
+package raven
+
+type Writer struct {
+	Client *Client
+	Level  Severity
+}
+
+// Write formats the byte slice p into a string, and sends a message to
+// Sentry at the severity level indicated by the Writer w.
+func (w *Writer) Write(p []byte) (int, error) {
+	message := string(p)
+
+	packet := NewPacket(message, &Message{message, nil})
+	packet.Level = w.Level
+	err := w.Client.Send(packet)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(p), nil
+}


### PR DESCRIPTION
From the [client design docs](http://sentry.readthedocs.org/en/latest/developer/client/index.html):

> Additionally, the following features are highly encouraged:
> - Automated error handling (e.g. default error handlers)
> - **Logging integration (to whatever standard solution is available)**
> - Non-blocking event submission
> - Basic data sanitization (e.g. filtering out values that look like passwords)

Go's "standard solution" is the [log](http://golang.org/pkg/log/#New) package, which takes an [io.Writer](http://golang.org/pkg/io/#Writer). Accordingly, raven.Writer is an io.Writer that writes a standard "message" to a Sentry client at a specified logging level.

This code snippet worked for me and demo's the functionality:

```
w := &raven.Writer{client, raven.INFO}
l := log.New(w, "", 0)
l.Print("If you're seeing this, it's workin'!")
```
