### PR TITLE
Set logger name

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,9 +71,9 @@ type Packet struct {
 	Project   string    `json:"project"`
 	Timestamp Timestamp `json:"timestamp"`
 	Level     Severity  `json:"level"`
+	Logger    string    `json:"logger"`
 
 	// Optional
-	Logger     string                 `json:"logger,omitempty"`
 	Platform   string                 `json:"platform,omitempty"`
 	Culprit    string                 `json:"culprit,omitempty"`
 	Tags       map[string]string      `json:"tags,omitempty"`
@@ -110,6 +110,9 @@ func (packet *Packet) Init(project string, parentTags map[string]string) error {
 	}
 	if packet.Level == 0 {
 		packet.Level = ERROR
+	}
+	if packet.Logger == "" {
+		packet.Logger = "root"
 	}
 	if packet.ServerName == "" {
 		packet.ServerName = hostname

--- a/client_test.go
+++ b/client_test.go
@@ -17,10 +17,11 @@ func TestPacketJSON(t *testing.T) {
 		Message:    "test",
 		Timestamp:  Timestamp(time.Date(2000, 01, 01, 0, 0, 0, 0, time.UTC)),
 		Level:      ERROR,
+		Logger:     "com.cupcake.raven-go.logger-test-packet-json",
 		Interfaces: []Interface{&Message{Message: "foo"}},
 	}
 
-	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":40,"sentry.interfaces.Message":{"message":"foo"}}`
+	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":40,"logger":"com.cupcake.raven-go.logger-test-packet-json","sentry.interfaces.Message":{"message":"foo"}}`
 	actual := string(packet.JSON())
 
 	if actual != expected {
@@ -43,6 +44,9 @@ func TestPacketInit(t *testing.T) {
 	}
 	if packet.Level != ERROR {
 		t.Errorf("incorrect Level: got %d, want %d", packet.Level, ERROR)
+	}
+	if packet.Logger != "root" {
+		t.Errorf("incorrect Logger: got %s, want %s", packet.Logger, "root")
 	}
 	if time.Time(packet.Timestamp).IsZero() {
 		t.Error("Timestamp is zero")

--- a/writer.go
+++ b/writer.go
@@ -3,6 +3,7 @@ package raven
 type Writer struct {
 	Client *Client
 	Level  Severity
+	Logger string // Logger name reported to Sentry
 }
 
 // Write formats the byte slice p into a string, and sends a message to
@@ -12,6 +13,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 
 	packet := NewPacket(message, &Message{message, nil})
 	packet.Level = w.Level
+	packet.Logger = w.Logger
 	w.Client.Capture(packet, nil)
 
 	return len(p), nil


### PR DESCRIPTION
`logger` is a required field (although a default is specified).
http://sentry.readthedocs.org/en/latest/developer/client/index.html#building-the-json-packet

If you want to use a `Writer` with the `log` pkg, you can specify the logger name there too.
