### PR TITLE
Only report in-app culprits.

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -23,10 +23,10 @@ type Stacktrace struct {
 func (s *Stacktrace) Class() string { return "sentry.interfaces.Stacktrace" }
 
 func (s *Stacktrace) Culprit() string {
-	if len(s.Frames) > 0 {
-		f := s.Frames[len(s.Frames)-1]
-		if f.Module != "" && f.Function != "" {
-			return f.Module + "." + f.Function
+	for i := len(s.Frames) - 1; i >= 0; i-- {
+		frame := s.Frames[i]
+		if *frame.InApp == true && frame.Module != "" && frame.Function != "" {
+			return frame.Module + "." + frame.Function
 		}
 	}
 	return ""


### PR DESCRIPTION
We start to get a whole bunch of repetitive culprits if we just always use the last frame; this change uses the last _in-app_ frame.

Closes cupcake/raven-go#16.
