### PR TITLE
Log levels should be strings

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,17 +22,17 @@ import (
 
 const userAgent = "go-raven/1.0"
 
-type Severity int
+type Severity string
 
 var ErrPacketDropped = errors.New("raven: packet dropped")
 
 // http://docs.python.org/2/howto/logging.html#logging-levels
 const (
-	DEBUG Severity = (iota + 1) * 10
-	INFO
-	WARNING
-	ERROR
-	FATAL
+	DEBUG   Severity = "debug"
+	INFO             = "info"
+	WARNING          = "warning"
+	ERROR            = "error"
+	FATAL            = "fatal"
 )
 
 type Timestamp time.Time
@@ -117,7 +117,7 @@ func (packet *Packet) Init(project string) error {
 	if time.Time(packet.Timestamp).IsZero() {
 		packet.Timestamp = Timestamp(time.Now())
 	}
-	if packet.Level == 0 {
+	if packet.Level == "" {
 		packet.Level = ERROR
 	}
 	if packet.Logger == "" {

--- a/client_test.go
+++ b/client_test.go
@@ -24,7 +24,7 @@ func TestPacketJSON(t *testing.T) {
 
 	packet.AddTags(map[string]string{"foo": "foo", "baz": "buzz"})
 
-	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":40,"logger":"com.cupcake.raven-go.logger-test-packet-json","tags":[["foo","bar"],["foo","foo"],["baz","buzz"]],"sentry.interfaces.Message":{"message":"foo"}}`
+	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.cupcake.raven-go.logger-test-packet-json","tags":[["foo","bar"],["foo","foo"],["baz","buzz"]],"sentry.interfaces.Message":{"message":"foo"}}`
 	actual := string(packet.JSON())
 
 	if actual != expected {


### PR DESCRIPTION
Clients are recommended to use strings for log levels since the integers are ambiguous between platforms. Integers are sorta deprecated unofficially.
