### PR TITLE
Expose client properties

### DIFF
--- a/client.go
+++ b/client.go
@@ -371,6 +371,13 @@ func (client *Client) ProjectID() string {
 	return client.projectID
 }
 
+func (client *Client) URL() string {
+	client.mu.RLock()
+	defer client.mu.RUnlock()
+
+	return client.url
+}
+
 // HTTPTransport is the default transport, delivering packets to Sentry via the
 // HTTP API.
 type HTTPTransport struct {


### PR DESCRIPTION
For my application, I need to access the project ID of a Raven client after it has been initialized. This could be done by exposing the property in the struct (as I have done in this PR) or by providing some getter method.
