### PR TITLE
Tag structure

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -90,3 +90,32 @@ func TestUnmarshalTag(t *testing.T) {
 		t.Errorf("incorrect Tag: wanted '%+v' and got '%+v'", expected, actual)
 	}
 }
+
+func TestUnmarshalTags(t *testing.T) {
+	tests := []struct {
+		Input    string
+		Expected *Tags
+	}{
+		{`{"foo":"bar","bar":"baz"}`, &Tags{
+			Tag{Key: "foo", Value: "bar"},
+			Tag{Key: "bar", Value: "baz"},
+		}},
+		{`[["foo","bar"],["bar","baz"]]`, &Tags{
+			Tag{Key: "foo", Value: "bar"},
+			Tag{Key: "bar", Value: "baz"},
+		}},
+	}
+
+	for _, test := range tests {
+		actual := new(Tags)
+		err := json.Unmarshal([]byte(test.Input), actual)
+
+		if err != nil {
+			t.Fatal("unable to decode JSON:", err)
+		}
+
+		if !reflect.DeepEqual(actual, test.Expected) {
+			t.Errorf("incorrect Tags: wanted '%+v' and got '%+v'", test.Expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Currently, tags are defined as follows:

```
type Tag struct {
    Key   string
    Value string
}
```

This seems somehwhat inconsistent with the [spec](http://sentry.readthedocs.org/en/latest/developer/client/index.html#building-the-json-packet), which provides the following examples:

```
{
    "tags": {
        "ios_version": "4.0",
        "context": "production"
    }
}
```

```
{
    "tags": [
        ["ios_version", "4.0"],
        ["context", "production"]
    ]
}
```

Considering the first example only, it seems that `Tags` could be replaced with `map[string]string`. This does not hold true for the second example though :-1: 
