### PR TITLE
allow capturing of errors with values of empty strings

### DIFF
--- a/client.go
+++ b/client.go
@@ -164,9 +164,6 @@ func NewPacket(message string, interfaces ...Interface) *Packet {
 // Init initializes required fields in a packet. It is typically called by
 // Client.Send/Report automatically.
 func (packet *Packet) Init(project string) error {
-	if packet.Message == "" {
-		return errors.New("raven: empty message")
-	}
 	if packet.Project == "" {
 		packet.Project = project
 	}


### PR DESCRIPTION
Sometimes 3rd party code return errors with empty string value `errors.New("")`,
in such case, the Raven client simply ignores the errors instead of capturing it.

this result in lose of error capturing.

The correct behavior is to capture an error as long as the err object exists regardless of the message value.

in any way, the zero value of an error object is nil and not an object with empty message string
