### PR TITLE
added the ability to provide optional extra data to captured errors and messages

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -143,3 +143,53 @@ func TestUnmarshalTimestamp(t *testing.T) {
 		t.Errorf("incorrect string; got %s, want %s", actual, expected)
 	}
 }
+
+func TestNewPacket(t *testing.T) {
+	interfaces := []Interface{&testInterface{}}
+	p := NewPacket("message", nil, interfaces...)
+
+	if p.Message != "message" {
+		t.Fail()
+	}
+
+	if !reflect.DeepEqual(interfaces, p.Interfaces) {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.Version"]; !ok {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.NumCPU"]; !ok {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.GOMAXPROCS"]; !ok {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.NumGoroutine"]; !ok {
+		t.Fail()
+	}
+
+	p = NewPacket("message", map[string]interface{}{"key1": "value1"}, interfaces...)
+	if _, ok := p.Extra["runtime.Version"]; !ok {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.NumCPU"]; !ok {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.GOMAXPROCS"]; !ok {
+		t.Fail()
+	}
+
+	if _, ok := p.Extra["runtime.NumGoroutine"]; !ok {
+		t.Fail()
+	}
+
+	if v, ok := p.Extra["key1"]; !ok || v != "value1" {
+		t.Fail()
+	}
+}

--- a/example/example.go
+++ b/example/example.go
@@ -35,7 +35,7 @@ func CheckError(err error, r *http.Request) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	packet := raven.NewPacket(err.Error(), raven.NewException(err, trace()), raven.NewHttp(r))
+	packet := raven.NewPacket(err.Error(), nil, raven.NewException(err, trace()), raven.NewHttp(r))
 	eventID, _ := client.Capture(packet, nil)
 	message := fmt.Sprintf("Error event with id \"%s\" - %s", eventID, err.Error())
 	log.Println(message)

--- a/examples_test.go
+++ b/examples_test.go
@@ -2,8 +2,8 @@ package raven
 
 import (
 	"fmt"
-	"net/http"
 	"log"
+	"net/http"
 )
 
 func Example() {
@@ -18,7 +18,7 @@ func Example() {
 		log.Fatal(err)
 	}
 	trace := NewStacktrace(0, 2, nil)
-	packet := NewPacket(raisedErr.Error(), NewException(raisedErr, trace), NewHttp(r))
+	packet := NewPacket(raisedErr.Error(), nil, NewException(raisedErr, trace), NewHttp(r))
 	eventID, ch := client.Capture(packet, nil)
 	if err = <-ch; err != nil {
 		log.Fatal(err)

--- a/writer.go
+++ b/writer.go
@@ -11,7 +11,7 @@ type Writer struct {
 func (w *Writer) Write(p []byte) (int, error) {
 	message := string(p)
 
-	packet := NewPacket(message, &Message{message, nil})
+	packet := NewPacket(message, nil, &Message{message, nil})
 	packet.Level = w.Level
 	packet.Logger = w.Logger
 	w.Client.Capture(packet, nil)


### PR DESCRIPTION
added the ability to provide optional extra data to captured errors and messages,
if `extra` is nil, previous behavior of adding the runtime info is maintained.

this functionality exists in other clients..

this change is not backward compatible as a new argument (which can be `nil`) is added to `NewPacket()`, `CaptureError()`, `CaptureMessage()` and `CapturePanic()`.
