### PR TITLE
fix severity constants types

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,10 +39,10 @@ type Severity string
 // http://docs.python.org/2/howto/logging.html#logging-levels
 const (
 	DEBUG   Severity = "debug"
-	INFO             = "info"
-	WARNING          = "warning"
-	ERROR            = "error"
-	FATAL            = "fatal"
+	INFO    Severity = "info"
+	WARNING Severity = "warning"
+	ERROR   Severity = "error"
+	FATAL   Severity = "fatal"
 )
 
 type Timestamp time.Time


### PR DESCRIPTION
This fixes the types on all the severities. Previously `DEBUG` was the only constant typed as `Severity`. All the others (`INFO`, `WARNING`, etc) were normal strings.

```
package main

import (
	"fmt"
	"reflect"

	"github.com/getsentry/raven-go"
)

func main() {
	fmt.Printf("raven.DEBUG: %s\n", reflect.TypeOf(raven.DEBUG))
	fmt.Printf("raven.INFO: %s\n", reflect.TypeOf(raven.INFO))
	fmt.Printf("raven.WARNING: %s\n", reflect.TypeOf(raven.WARNING))
	fmt.Printf("raven.ERROR: %s\n", reflect.TypeOf(raven.ERROR))
	fmt.Printf("raven.FATAL: %s\n", reflect.TypeOf(raven.FATAL))
}
```

```
raven.DEBUG: raven.Severity
raven.INFO: string
raven.WARNING: string
raven.ERROR: string
raven.FATAL: string
```