### PR TITLE
stacktrace: always explicitly send `in_app` key

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -46,7 +46,7 @@ type StacktraceFrame struct {
 	ContextLine  string   `json:"context_line,omitempty"`
 	PreContext   []string `json:"pre_context,omitempty"`
 	PostContext  []string `json:"post_context,omitempty"`
-	InApp        bool     `json:"in_app,omitempty"`
+	InApp        bool     `json:"in_app"`
 }
 
 // Intialize and populate a new stacktrace, skipping skip frames.


### PR DESCRIPTION
When only some frames have this set, Sentry is confused and does the wrong thing.