### PR TITLE
Add a link back to your client docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 raven is a Go client for the [Sentry](https://github.com/getsentry/sentry)
 event/error logging system.
 
-[**Documentation**](http://godoc.org/github.com/getsentry/raven-go).
+- [**API Documentation**](https://godoc.org/github.com/getsentry/raven-go)
+- [**Usage and Examples**](https://docs.getsentry.com/hosted/clients/go/)
 
 ## Installation
 


### PR DESCRIPTION
The GoDoc is great for API documentation, but sometimes users just want to be able to see what it looks like in action. You actually have a great example of this on your website, but it's not documented anywhere in the repo :smile: