### PR TITLE
fix incompatable modules attribute on packet

### DIFF
--- a/client.go
+++ b/client.go
@@ -147,7 +147,7 @@ type Packet struct {
 	ServerName string                 `json:"server_name,omitempty"`
 	Release    string                 `json:"release,omitempty"`
 	Tags       Tags                   `json:"tags,omitempty"`
-	Modules    []map[string]string    `json:"modules,omitempty"`
+	Modules    map[string]string      `json:"modules,omitempty"`
 	Extra      map[string]interface{} `json:"extra,omitempty"`
 
 	Interfaces []Interface `json:"-"`

--- a/client_test.go
+++ b/client_test.go
@@ -25,13 +25,14 @@ func TestPacketJSON(t *testing.T) {
 		Level:      ERROR,
 		Logger:     "com.getsentry.raven-go.logger-test-packet-json",
 		Tags:       []Tag{Tag{"foo", "bar"}},
+		Modules:    map[string]string{"foo": "bar"},
 		Interfaces: []Interface{&Message{Message: "foo"}},
 	}
 
 	packet.AddTags(map[string]string{"foo": "foo"})
 	packet.AddTags(map[string]string{"baz": "buzz"})
 
-	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"],["foo","foo"],["baz","buzz"]],"logentry":{"message":"foo"}}`
+	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"],["foo","foo"],["baz","buzz"]],"modules":{"foo":"bar"},"logentry":{"message":"foo"}}`
 	actual := string(packet.JSON())
 
 	if actual != expected {
@@ -52,10 +53,11 @@ func TestPacketJSONNilInterface(t *testing.T) {
 		Level:      ERROR,
 		Logger:     "com.getsentry.raven-go.logger-test-packet-json",
 		Tags:       []Tag{Tag{"foo", "bar"}},
+		Modules:    map[string]string{"foo": "bar"},
 		Interfaces: []Interface{&Message{Message: "foo"}, nil},
 	}
 
-	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"]],"logentry":{"message":"foo"}}`
+	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"]],"modules":{"foo":"bar"},"logentry":{"message":"foo"}}`
 	actual := string(packet.JSON())
 
 	if actual != expected {


### PR DESCRIPTION
when this was a list of maps I was getting the following error on sentry:

![2016-01-03-010612_1541x575_scrot](https://cloud.githubusercontent.com/assets/794070/12076867/9448517c-b1b7-11e5-8e74-e31c00e6dee9.png)

changing to just a map fixes this. Modules doesn't seem to be full implemented so this doesn't appear to break anything.