### PR TITLE
Add Fingerprint to Packet struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -142,13 +142,14 @@ type Packet struct {
 	Logger    string    `json:"logger"`
 
 	// Optional
-	Platform   string                 `json:"platform,omitempty"`
-	Culprit    string                 `json:"culprit,omitempty"`
-	ServerName string                 `json:"server_name,omitempty"`
-	Release    string                 `json:"release,omitempty"`
-	Tags       Tags                   `json:"tags,omitempty"`
-	Modules    map[string]string      `json:"modules,omitempty"`
-	Extra      map[string]interface{} `json:"extra,omitempty"`
+	Platform    string                 `json:"platform,omitempty"`
+	Culprit     string                 `json:"culprit,omitempty"`
+	ServerName  string                 `json:"server_name,omitempty"`
+	Release     string                 `json:"release,omitempty"`
+	Tags        Tags                   `json:"tags,omitempty"`
+	Modules     map[string]string      `json:"modules,omitempty"`
+	Fingerprint string                 `json:"fingerprint,omitempty"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
 
 	Interfaces []Interface `json:"-"`
 }

--- a/client_test.go
+++ b/client_test.go
@@ -14,25 +14,26 @@ func (t *testInterface) Culprit() string { return "codez" }
 
 func TestPacketJSON(t *testing.T) {
 	packet := &Packet{
-		Project:    "1",
-		EventID:    "2",
-		Platform:   "linux",
-		Culprit:    "caused_by",
-		ServerName: "host1",
-		Release:    "721e41770371db95eee98ca2707686226b993eda",
-		Message:    "test",
-		Timestamp:  Timestamp(time.Date(2000, 01, 01, 0, 0, 0, 0, time.UTC)),
-		Level:      ERROR,
-		Logger:     "com.getsentry.raven-go.logger-test-packet-json",
-		Tags:       []Tag{Tag{"foo", "bar"}},
-		Modules:    map[string]string{"foo": "bar"},
-		Interfaces: []Interface{&Message{Message: "foo"}},
+		Project:     "1",
+		EventID:     "2",
+		Platform:    "linux",
+		Culprit:     "caused_by",
+		ServerName:  "host1",
+		Release:     "721e41770371db95eee98ca2707686226b993eda",
+		Message:     "test",
+		Timestamp:   Timestamp(time.Date(2000, 01, 01, 0, 0, 0, 0, time.UTC)),
+		Level:       ERROR,
+		Logger:      "com.getsentry.raven-go.logger-test-packet-json",
+		Tags:        []Tag{Tag{"foo", "bar"}},
+		Modules:     map[string]string{"foo": "bar"},
+		Fingerprint: "a-custom-fingerprint",
+		Interfaces:  []Interface{&Message{Message: "foo"}},
 	}
 
 	packet.AddTags(map[string]string{"foo": "foo"})
 	packet.AddTags(map[string]string{"baz": "buzz"})
 
-	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"],["foo","foo"],["baz","buzz"]],"modules":{"foo":"bar"},"logentry":{"message":"foo"}}`
+	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"],["foo","foo"],["baz","buzz"]],"modules":{"foo":"bar"},"fingerprint":"a-custom-fingerprint","logentry":{"message":"foo"}}`
 	actual := string(packet.JSON())
 
 	if actual != expected {
@@ -42,22 +43,23 @@ func TestPacketJSON(t *testing.T) {
 
 func TestPacketJSONNilInterface(t *testing.T) {
 	packet := &Packet{
-		Project:    "1",
-		EventID:    "2",
-		Platform:   "linux",
-		Culprit:    "caused_by",
-		ServerName: "host1",
-		Release:    "721e41770371db95eee98ca2707686226b993eda",
-		Message:    "test",
-		Timestamp:  Timestamp(time.Date(2000, 01, 01, 0, 0, 0, 0, time.UTC)),
-		Level:      ERROR,
-		Logger:     "com.getsentry.raven-go.logger-test-packet-json",
-		Tags:       []Tag{Tag{"foo", "bar"}},
-		Modules:    map[string]string{"foo": "bar"},
-		Interfaces: []Interface{&Message{Message: "foo"}, nil},
+		Project:     "1",
+		EventID:     "2",
+		Platform:    "linux",
+		Culprit:     "caused_by",
+		ServerName:  "host1",
+		Release:     "721e41770371db95eee98ca2707686226b993eda",
+		Message:     "test",
+		Timestamp:   Timestamp(time.Date(2000, 01, 01, 0, 0, 0, 0, time.UTC)),
+		Level:       ERROR,
+		Logger:      "com.getsentry.raven-go.logger-test-packet-json",
+		Tags:        []Tag{Tag{"foo", "bar"}},
+		Modules:     map[string]string{"foo": "bar"},
+		Fingerprint: "a-custom-fingerprint",
+		Interfaces:  []Interface{&Message{Message: "foo"}, nil},
 	}
 
-	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"]],"modules":{"foo":"bar"},"logentry":{"message":"foo"}}`
+	expected := `{"message":"test","event_id":"2","project":"1","timestamp":"2000-01-01T00:00:00","level":"error","logger":"com.getsentry.raven-go.logger-test-packet-json","platform":"linux","culprit":"caused_by","server_name":"host1","release":"721e41770371db95eee98ca2707686226b993eda","tags":[["foo","bar"]],"modules":{"foo":"bar"},"fingerprint":"a-custom-fingerprint","logentry":{"message":"foo"}}`
 	actual := string(packet.JSON())
 
 	if actual != expected {


### PR DESCRIPTION
This allows use of the `fingerprint` attribute which was added to the client API in 7.7.0.