### PR TITLE
NewStacktrace should return nil instead of a Stacktrace with no frames

### DIFF
--- a/exception_test.go
+++ b/exception_test.go
@@ -1,6 +1,7 @@
 package raven
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -25,5 +26,14 @@ func TestNewException(t *testing.T) {
 		if actual.Module != test.Module {
 			t.Errorf("incorrect Module: got %s, want %s", actual.Module, test.Module)
 		}
+	}
+}
+
+func TestNewException_JSON(t *testing.T) {
+	expected := `{"value":"foobar","type":"*errors.errorString"}`
+	e := NewException(errors.New("foobar"), nil)
+	b, _ := json.Marshal(e)
+	if string(b) != expected {
+		t.Errorf("incorrect JSON: got %s, want %s", string(b), expected)
 	}
 }

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -69,6 +69,14 @@ func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktra
 			frames = append(frames, frame)
 		}
 	}
+	// If there are no frames, the entire stacktrace is nil
+	if len(frames) == 0 {
+		return nil
+	}
+	// Optimize the path where there's only 1 frame
+	if len(frames) == 1 {
+		return &Stacktrace{frames}
+	}
 	// Sentry wants the frames with the oldest first, so reverse them
 	for i, j := 0, len(frames)-1; i < j; i, j = i+1, j-1 {
 		frames[i], frames[j] = frames[j], frames[i]

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -133,3 +133,10 @@ func TestNewStacktrace_outOfBounds(t *testing.T) {
 		t.Errorf("incorrect ContextLine: %#v", f.ContextLine)
 	}
 }
+
+func TestNewStacktrace_noFrames(t *testing.T) {
+	st := NewStacktrace(999999999, 0, []string{})
+	if st != nil {
+		t.Errorf("expected st.Frames to be nil:", st)
+	}
+}


### PR DESCRIPTION
See: https://github.com/getsentry/sentry/pull/3042