### PR TITLE
Log error message in RecoveryHandler

### DIFF
--- a/http.go
+++ b/http.go
@@ -3,6 +3,7 @@ package raven
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -71,6 +72,7 @@ func RecoveryHandler(handler func(http.ResponseWriter, *http.Request)) func(http
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rval := recover(); rval != nil {
+				log.Print(rval)
 				debug.PrintStack()
 				rvalStr := fmt.Sprint(rval)
 				packet := NewPacket(rvalStr, NewException(errors.New(rvalStr), NewStacktrace(2, 3, nil)), NewHttp(r))


### PR DESCRIPTION
The default behavior of the default Go http panic handler is to display the error message and the stack trace. When I use `raven.RecoveryHandler` it outputs only the stack trace, which makes debugging difficult.

Default behavior:
```
func handler(w http.ResponseWriter, r *http.Request) {
    var x []int
    x[1] = 1
}

func main() {
    http.HandleFunc("/", handler)
    http.ListenAndServe(":8080", nil)
}

2016/07/11 13:49:24 http: panic serving [::1]:50020: runtime error: index out of range
goroutine 25 [running]:
[stack trace]
```

With `RecoveryHandler`:
```
func main() {
    http.HandleFunc("/", raven.RecoveryHandler(handler))
    http.ListenAndServe(":8080", nil)
}

goroutine 21 [running]:
[stack trace]
```

This pull request makes `RecoveryHandler` output look like:
```
2016/07/11 14:19:41 runtime error: index out of range
goroutine 6 [running]:
[stack trace]
```