### PR TITLE
Close the client's queue when SetDSN is called with an empty DSN

### DIFF
--- a/client.go
+++ b/client.go
@@ -307,13 +307,17 @@ func newClient(tags map[string]string) *Client {
 	return client
 }
 
-// New constructs a new Sentry client instance
+// New constructs a new Sentry client instance.
+//
+// Caller must call client.SetDSN(nil) to clean up client after use.
 func New(dsn string) (*Client, error) {
 	client := newClient(nil)
 	return client, client.SetDSN(dsn)
 }
 
 // NewWithTags constructs a new Sentry client instance with default tags.
+//
+// Caller must call client.SetDSN(nil) to clean up client after use.
 func NewWithTags(dsn string, tags map[string]string) (*Client, error) {
 	client := newClient(tags)
 	return client, client.SetDSN(dsn)
@@ -323,6 +327,8 @@ func NewWithTags(dsn string, tags map[string]string) (*Client, error) {
 // handle packets sent by Client.Report.
 //
 // Deprecated: use New and NewWithTags instead
+//
+// Caller must call client.SetDSN(nil) to clean up client after use.
 func NewClient(dsn string, tags map[string]string) (*Client, error) {
 	client := newClient(tags)
 	return client, client.SetDSN(dsn)
@@ -361,6 +367,8 @@ var DefaultClient = newClient(nil)
 
 // SetDSN updates a client with a new DSN. It safe to call after and
 // concurrently with calls to Report and Send.
+//
+// Caller must call client.SetDSN(nil) to clean up client after use.
 func (client *Client) SetDSN(dsn string) error {
 	if dsn == "" {
 		close(client.queue)
@@ -403,6 +411,8 @@ func (client *Client) SetDSN(dsn string) error {
 }
 
 // Sets the DSN for the default *Client instance
+//
+// Caller must call SetDSN(nil) to clean up client after use.
 func SetDSN(dsn string) error { return DefaultClient.SetDSN(dsn) }
 
 // SetRelease sets the "release" tag.

--- a/client.go
+++ b/client.go
@@ -309,7 +309,7 @@ func newClient(tags map[string]string) *Client {
 
 // New constructs a new Sentry client instance.
 //
-// Caller must call client.SetDSN(nil) to clean up client after use.
+// Caller must call client.SetDSN("") to clean up client after use.
 func New(dsn string) (*Client, error) {
 	client := newClient(nil)
 	return client, client.SetDSN(dsn)
@@ -317,7 +317,7 @@ func New(dsn string) (*Client, error) {
 
 // NewWithTags constructs a new Sentry client instance with default tags.
 //
-// Caller must call client.SetDSN(nil) to clean up client after use.
+// Caller must call client.SetDSN("") to clean up client after use.
 func NewWithTags(dsn string, tags map[string]string) (*Client, error) {
 	client := newClient(tags)
 	return client, client.SetDSN(dsn)
@@ -328,7 +328,7 @@ func NewWithTags(dsn string, tags map[string]string) (*Client, error) {
 //
 // Deprecated: use New and NewWithTags instead
 //
-// Caller must call client.SetDSN(nil) to clean up client after use.
+// Caller must call client.SetDSN("") to clean up client after use.
 func NewClient(dsn string, tags map[string]string) (*Client, error) {
 	client := newClient(tags)
 	return client, client.SetDSN(dsn)
@@ -368,7 +368,7 @@ var DefaultClient = newClient(nil)
 // SetDSN updates a client with a new DSN. It safe to call after and
 // concurrently with calls to Report and Send.
 //
-// Caller must call client.SetDSN(nil) to clean up client after use.
+// Caller must call client.SetDSN("") to clean up client after use.
 func (client *Client) SetDSN(dsn string) error {
 	if dsn == "" {
 		close(client.queue)
@@ -412,7 +412,7 @@ func (client *Client) SetDSN(dsn string) error {
 
 // Sets the DSN for the default *Client instance
 //
-// Caller must call SetDSN(nil) to clean up client after use.
+// Caller must call SetDSN("") to clean up client after use.
 func SetDSN(dsn string) error { return DefaultClient.SetDSN(dsn) }
 
 // SetRelease sets the "release" tag.

--- a/client.go
+++ b/client.go
@@ -404,8 +404,6 @@ func (client *Client) SetDSN(dsn string) error {
 
 	client.authHeader = fmt.Sprintf("Sentry sentry_version=4, sentry_key=%s, sentry_secret=%s", publicKey, secretKey)
 
-	go client.worker()
-
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -304,12 +304,14 @@ func newClient(tags map[string]string) *Client {
 		context:   &context{},
 		queue:     make(chan *outgoingPacket, MaxQueueBuffer),
 	}
+	go client.worker()
+	client.SetDSN(os.Getenv("SENTRY_DSN"))
 	return client
 }
 
 // New constructs a new Sentry client instance.
 //
-// Caller must call client.SetDSN("") to clean up client after use.
+// Caller must call Close to clean up client after use.
 func New(dsn string) (*Client, error) {
 	client := newClient(nil)
 	return client, client.SetDSN(dsn)
@@ -317,7 +319,7 @@ func New(dsn string) (*Client, error) {
 
 // NewWithTags constructs a new Sentry client instance with default tags.
 //
-// Caller must call client.SetDSN("") to clean up client after use.
+// Caller must call Close to clean up client after use.
 func NewWithTags(dsn string, tags map[string]string) (*Client, error) {
 	client := newClient(tags)
 	return client, client.SetDSN(dsn)
@@ -328,7 +330,7 @@ func NewWithTags(dsn string, tags map[string]string) (*Client, error) {
 //
 // Deprecated: use New and NewWithTags instead
 //
-// Caller must call client.SetDSN("") to clean up client after use.
+// Caller must call Close to clean up client after use.
 func NewClient(dsn string, tags map[string]string) (*Client, error) {
 	client := newClient(tags)
 	return client, client.SetDSN(dsn)
@@ -367,11 +369,8 @@ var DefaultClient = newClient(nil)
 
 // SetDSN updates a client with a new DSN. It safe to call after and
 // concurrently with calls to Report and Send.
-//
-// Caller must call client.SetDSN("") to clean up client after use.
 func (client *Client) SetDSN(dsn string) error {
 	if dsn == "" {
-		close(client.queue)
 		return nil
 	}
 
@@ -411,8 +410,6 @@ func (client *Client) SetDSN(dsn string) error {
 }
 
 // Sets the DSN for the default *Client instance
-//
-// Caller must call SetDSN("") to clean up client after use.
 func SetDSN(dsn string) error { return DefaultClient.SetDSN(dsn) }
 
 // SetRelease sets the "release" tag.

--- a/client.go
+++ b/client.go
@@ -365,6 +365,7 @@ var DefaultClient = newClient(nil)
 // concurrently with calls to Report and Send.
 func (client *Client) SetDSN(dsn string) error {
 	if dsn == "" {
+		close(client.queue)
 		return nil
 	}
 

--- a/client.go
+++ b/client.go
@@ -304,8 +304,6 @@ func newClient(tags map[string]string) *Client {
 		context:   &context{},
 		queue:     make(chan *outgoingPacket, MaxQueueBuffer),
 	}
-	go client.worker()
-	client.SetDSN(os.Getenv("SENTRY_DSN"))
 	return client
 }
 
@@ -398,6 +396,8 @@ func (client *Client) SetDSN(dsn string) error {
 	client.url = uri.String()
 
 	client.authHeader = fmt.Sprintf("Sentry sentry_version=4, sentry_key=%s, sentry_secret=%s", publicKey, secretKey)
+
+	go client.worker()
 
 	return nil
 }

--- a/example/example.go
+++ b/example/example.go
@@ -18,7 +18,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer client.SetDSN("")
+	defer client.Close()
 	httpReq, _ := http.NewRequest("GET", "http://example.com/foo?bar=true", nil)
 	httpReq.RemoteAddr = "127.0.0.1:80"
 	httpReq.Header = http.Header{"Content-Type": {"text/html"}, "Content-Length": {"42"}}
@@ -36,7 +36,7 @@ func CheckError(err error, r *http.Request) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer client.SetDSN("")
+	defer client.Close()
 	packet := raven.NewPacket(err.Error(), raven.NewException(err, trace()), raven.NewHttp(r))
 	eventID, _ := client.Capture(packet, nil)
 	message := fmt.Sprintf("Error event with id \"%s\" - %s", eventID, err.Error())

--- a/example/example.go
+++ b/example/example.go
@@ -18,7 +18,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer client.SetDSN(nil)
+	defer client.SetDSN("")
 	httpReq, _ := http.NewRequest("GET", "http://example.com/foo?bar=true", nil)
 	httpReq.RemoteAddr = "127.0.0.1:80"
 	httpReq.Header = http.Header{"Content-Type": {"text/html"}, "Content-Length": {"42"}}
@@ -36,7 +36,7 @@ func CheckError(err error, r *http.Request) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer client.SetDSN(nil)
+	defer client.SetDSN("")
 	packet := raven.NewPacket(err.Error(), raven.NewException(err, trace()), raven.NewHttp(r))
 	eventID, _ := client.Capture(packet, nil)
 	message := fmt.Sprintf("Error event with id \"%s\" - %s", eventID, err.Error())

--- a/example/example.go
+++ b/example/example.go
@@ -18,6 +18,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer client.SetDSN(nil)
 	httpReq, _ := http.NewRequest("GET", "http://example.com/foo?bar=true", nil)
 	httpReq.RemoteAddr = "127.0.0.1:80"
 	httpReq.Header = http.Header{"Content-Type": {"text/html"}, "Content-Length": {"42"}}
@@ -35,6 +36,7 @@ func CheckError(err error, r *http.Request) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer client.SetDSN(nil)
 	packet := raven.NewPacket(err.Error(), raven.NewException(err, trace()), raven.NewHttp(r))
 	eventID, _ := client.Capture(packet, nil)
 	message := fmt.Sprintf("Error event with id \"%s\" - %s", eventID, err.Error())


### PR DESCRIPTION
Note: This means `SetDSN(nil)` must be called after `SetDSN(dsn)`, and only exactly once.

Fixes #90

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-go/93)

<!-- Reviewable:end -->
