### PR TITLE
Add Origin HTTP header

### DIFF
--- a/client.go
+++ b/client.go
@@ -721,6 +721,7 @@ func (t *HTTPTransport) Send(url, authHeader string, packet *Packet) error {
 	req.Header.Set("X-Sentry-Auth", authHeader)
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Origin", "")
 	res, err := t.Http.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Someone want use raven-go in client environment without secret key, but current the SDK don't pass an Origin header to Server

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-go/101)
<!-- Reviewable:end -->
