### PR TITLE
Panic would occur due to unchecked slice access.

### DIFF
--- a/client.go
+++ b/client.go
@@ -248,7 +248,9 @@ func (packet *Packet) JSON() []byte {
 
 	if len(interfaces) > 0 {
 		interfaceJSON, _ := json.Marshal(interfaces)
-		packetJSON[len(packetJSON)-1] = ','
+		if len(packetJSON) > 1 {
+			packetJSON[len(packetJSON)-1] = ','
+		}
 		packetJSON = append(packetJSON, interfaceJSON[1:]...)
 	}
 


### PR DESCRIPTION
Don't know if this was an unexpected case or if there are further repercussions,
 but having the check seems like a no-brainer. 
Panic in your error tracking client is rather nasty. :face_with_head_bandage: 

Please let me know if there's something else I need to do to get this merged.