### PR TITLE
create exceptions type to support chained errors

### DIFF
--- a/exception.go
+++ b/exception.go
@@ -40,6 +40,8 @@ func (e *Exception) Culprit() string {
 	return e.Stacktrace.Culprit()
 }
 
+// Exceptions allows for chained errors
+// https://docs.sentry.io/clientdev/interfaces/exception/
 type Exceptions struct {
 	// Required
 	Values []*Exception `json:"values"`

--- a/exception.go
+++ b/exception.go
@@ -39,3 +39,10 @@ func (e *Exception) Culprit() string {
 	}
 	return e.Stacktrace.Culprit()
 }
+
+type Exceptions struct {
+	// Required
+	Values []*Exception `json:"values"`
+}
+
+func (es Exceptions) Class() string { return "exception" }


### PR DESCRIPTION
This PR resolves #120 by adding a type which will serialize to https://docs.sentry.io/clientdev/interfaces/exception/ When creating a packet you can either include an Exceptions or an Exception type but not both.