### PR TITLE
stacktrace.go: fileContext: Cache errors to avoid repeated syscalls

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -174,6 +174,12 @@ func fileContext(filename string, line, context int) ([][]byte, int) {
 		lines = bytes.Split(data, []byte{'\n'})
 		fileCache[filename] = lines
 	}
+
+	if lines == nil {
+		// cached error from ReadFile: return no lines
+		return nil, 0
+	}
+
 	line-- // stack trace lines are 1-indexed
 	start := line - context
 	var idx int

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -165,6 +165,10 @@ func fileContext(filename string, line, context int) ([][]byte, int) {
 	if !ok {
 		data, err := ioutil.ReadFile(filename)
 		if err != nil {
+			// cache errors as nil slice: code below handles it correctly
+			// otherwise when missing the source or running as a different user, we try
+			// reading the file on each error which is unnecessary
+			fileCache[filename] = nil
 			return nil, 0
 		}
 		lines = bytes.Split(data, []byte{'\n'})

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -3,6 +3,8 @@ package raven
 import (
 	"fmt"
 	"go/build"
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -57,7 +59,7 @@ func TestStacktrace(t *testing.T) {
 	if f.Module != thisPackage {
 		t.Error("incorrect Module:", f.Module)
 	}
-	if f.Lineno != 85 {
+	if f.Lineno != 87 {
 		t.Error("incorrect Lineno:", f.Lineno)
 	}
 	if f.ContextLine != "\treturn NewStacktrace(0, 2, []string{thisPackage})" {
@@ -138,5 +140,49 @@ func TestNewStacktrace_noFrames(t *testing.T) {
 	st := NewStacktrace(999999999, 0, []string{})
 	if st != nil {
 		t.Errorf("expected st.Frames to be nil:", st)
+	}
+}
+
+func TestFileContext(t *testing.T) {
+	// reset the cache
+	fileCache = make(map[string][][]byte)
+
+	tempdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal("failed to create temporary directory:", err)
+	}
+	defer os.RemoveAll(tempdir)
+
+	okPath := filepath.Join(tempdir, "ok")
+	missingPath := filepath.Join(tempdir, "missing")
+	noPermissionPath := filepath.Join(tempdir, "noperms")
+
+	err = ioutil.WriteFile(okPath, []byte("hello\nworld\n"), 0600)
+	if err != nil {
+		t.Fatal("failed writing file:", err)
+	}
+	err = ioutil.WriteFile(noPermissionPath, []byte("no access\n"), 0000)
+	if err != nil {
+		t.Fatal("failed writing file:", err)
+	}
+
+	tests := []struct {
+		path          string
+		expectedLines int
+		expectedIndex int
+	}{
+		{okPath, 1, 0},
+		{missingPath, 0, 0},
+		{noPermissionPath, 0, 0},
+	}
+	for i, test := range tests {
+		lines, index := fileContext(test.path, 1, 0)
+		if !(len(lines) == test.expectedLines && index == test.expectedIndex) {
+			t.Errorf("%d: fileContext(%#v, 1, 0) = %v, %v; expected len()=%d, %d",
+				i, test.path, lines, index, test.expectedLines, test.expectedIndex)
+		}
+		if len(fileCache) != i+1 {
+			t.Errorf("%d: result was not cached; len(fileCached)=%d", i, len(fileCache))
+		}
 	}
 }


### PR DESCRIPTION
If the source files are missing or owned by the wrong user, every
call to NewStacktrace causes an attempt to open and read the file.
This causes wasted work on servers that are deployed without their
source code.

Change fileContext to cache errors as an empty file (nil slice). This
changes this function to only try to read each unique file once.
Fixes issue #128.