### PR TITLE
Client.Capture: Return closed chan for nil clients.

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,14 +52,6 @@ const (
 
 type Timestamp time.Time
 
-// return by Capture for nil clients
-var closedChan chan error
-
-func init() {
-	closedChan = make(chan error)
-	close(closedChan)
-}
-
 func (t Timestamp) MarshalJSON() ([]byte, error) {
 	return []byte(time.Time(t).UTC().Format(timestampFormat)), nil
 }
@@ -502,11 +494,12 @@ func (client *Client) worker() {
 // when client is nil. A channel is provided if it is important to check for a
 // send's success.
 func (client *Client) Capture(packet *Packet, captureTags map[string]string) (eventID string, ch chan error) {
+	ch = make(chan error, 1)
+
 	if client == nil {
-		if client == nil {
-			// return a chan that always returns nil when the caller receives from it
-			return "", closedChan
-		}
+		// return a chan that always returns nil when the caller receives from it
+		close(ch)
+		return
 	}
 
 	if client.shouldExcludeErr(packet.Message) {
@@ -517,8 +510,6 @@ func (client *Client) Capture(packet *Packet, captureTags map[string]string) (ev
 	// *Must* call client.wg.Done() on any path that indicates that an event was
 	// finished being acted upon, whether success or failure
 	client.wg.Add(1)
-
-	ch = make(chan error, 1)
 
 	// Merge capture tags and client tags
 	packet.AddTags(captureTags)

--- a/client_test.go
+++ b/client_test.go
@@ -213,3 +213,16 @@ func TestUnmarshalTimestamp(t *testing.T) {
 		t.Errorf("incorrect string; got %s, want %s", actual, expected)
 	}
 }
+
+func TestNilClient(t *testing.T) {
+	var client *Client = nil
+	eventID, ch := client.Capture(nil, nil)
+	if eventID != "" {
+		t.Error("expected empty eventID:", eventID)
+	}
+	// wait on ch: no send should succeed immediately
+	err := <-ch
+	if err != nil {
+		t.Error("expected nil err:", err)
+	}
+}


### PR DESCRIPTION
The API docs state that Capture "is a no-op when client is nil." This
suggests that there should be no errors when calling it, so receiving
an error from the error chan result should immediately return nil.
Previously, it would return a nil chan. Receiving from a nil chan
blocks forever, which caused callers to need to check for nil clients
in some cases.

Change Capture to return a closed chan for nil clients, which will
immediately return nil. Fixes #129.