### PR TITLE
Specify proxy function for http transport

### DIFF
--- a/client.go
+++ b/client.go
@@ -317,6 +317,7 @@ func newTransport() Transport {
 	} else {
 		t.Client = &http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: rootCAs},
 			},
 		}


### PR DESCRIPTION
The client does not use `DefaultTransport` or `DefaultClient` and hence, HTTP proxies cannot be set.

This small modification allows to set proxy from the environment through `http_proxy` and `no_proxy`.