### PR TITLE
[WIP] Experimental support for stacktrace of github.com/pkg/errors.

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,6 +23,7 @@ import (
 	"time"
 
 	"github.com/certifi/gocertifi"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -617,7 +617,33 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 		return ""
 	}
 
-	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, NewStacktrace(1, 3, client.includePaths)))...)
+	var stacktrace *Stacktrace
+	stacktracer, errHasStacktrace := err.(interface {
+		StackTrace() errors.StackTrace
+	})
+	if errHasStacktrace {
+		var frames []*StacktraceFrame
+		for _, f := range stacktracer.StackTrace() {
+			pc := uintptr(f) - 1
+			fn := runtime.FuncForPC(pc)
+			var file string
+			var line int
+			if fn != nil {
+				file, line = fn.FileLine(pc)
+			} else {
+				file = "unknown"
+			}
+			frame := NewStacktraceFrame(pc, file, line, 3, client.IncludePaths())
+			if frame != nil {
+				frames = append([]*StacktraceFrame{frame}, frames...)
+			}
+		}
+		stacktrace = &Stacktrace{Frames: frames}
+	} else {
+		stacktrace = NewStacktrace(1, 3, client.includePaths)
+	}
+
+	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, stacktrace))...)
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID


### PR DESCRIPTION
This is a work in progress PR.
Currently implemented only what just we want.

- [x] Let `raven.CaptureError(err,...)` use stacktrace of err if available.
- [ ] Support other Capture functions like CapturePanic
