### PR TITLE
Fix functionName for stacktrace

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -157,7 +157,7 @@ func functionName(pc uintptr, filePath string) (pack string, name string) {
 //
 // If the extraction fails, pack = "", name = funcName.
 func extractFunctionName(filePath, funcName string) (pack, name string) {
-	if f, err := url.PathUnescape(funcName); err != nil {
+	if f, err := url.QueryUnescape(funcName); err != nil {
 		return "", funcName
 	} else {
 		funcName = f

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -139,7 +139,7 @@ func TestNewStacktrace_outOfBounds(t *testing.T) {
 func TestNewStacktrace_noFrames(t *testing.T) {
 	st := NewStacktrace(999999999, 0, []string{})
 	if st != nil {
-		t.Errorf("expected st.Frames to be nil:", st)
+		t.Error("expected st.Frames to be nil")
 	}
 }
 func TestFileContext(t *testing.T) {


### PR DESCRIPTION
Prior to this commit, functionName does not return the proper value for pack and name. For example, if "github.com/example/package-name.(*SomeStruct).MethodA" is given by fn.Name(), the resulting values of functionName are the following:

- pack = package-name.(*SomeStruct)
- name = MethodA

But I think the correct values should be:

- pack = package-name
- name = (*SomeStruct).MethodA

This PR is an attempt to fix this and get the proper values by using the package name extracted from the file path.

I also found that the runtime.Func.Name() escapes the string, i.e.  `dot.package` will be escaped to `dot%2epackage`.  Therefore added the [line to "undo" that](https://github.com/shihanng/raven-go/blob/9e0322c0fbbed2a5b2a05b231c0d36a65114e576/stacktrace.go#L160).

Please kindly have a look and let me know what you think about these changes.

Thank you.