### PR TITLE
sampleRate parameter in Client to allow sampling in client side

### DIFF
--- a/client.go
+++ b/client.go
@@ -641,7 +641,9 @@ func (client *Client) CaptureMessageAndWait(message string, tags map[string]stri
 
 	packet := NewPacket(message, append(append(interfaces, client.context.interfaces()...), &Message{message, nil})...)
 	eventID, ch := client.Capture(packet, tags)
-	<-ch
+	if eventID != "" {
+		<-ch
+	}
 
 	return eventID
 }
@@ -686,7 +688,9 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 
 	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, NewStacktrace(1, 3, client.includePaths)))...)
 	eventID, ch := client.Capture(packet, tags)
-	<-ch
+	if eventID != "" {
+		<-ch
+	}
 
 	return eventID
 }
@@ -762,7 +766,9 @@ func (client *Client) CapturePanicAndWait(f func(), tags map[string]string, inte
 
 		var ch chan error
 		errorID, ch = client.Capture(packet, tags)
-		<-ch
+		if errorID != "" {
+			<-ch
+		}
 	}()
 
 	f()

--- a/client.go
+++ b/client.go
@@ -538,7 +538,7 @@ func (client *Client) Capture(packet *Packet, captureTags map[string]string) (ev
 		return
 	}
 
-	if mrand.Float32() > client.sampleRate {
+	if client.sampleRate < 1.0 && mrand.Float32() > client.sampleRate {
 		return
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -146,6 +146,35 @@ func TestSetDSN(t *testing.T) {
 	}
 }
 
+func TestNewClient(t *testing.T) {
+	client := newClient(nil)
+	if client.sampleRate != 1.0 {
+		t.Error("invalid default sample rate")
+	}
+}
+
+func TestSetSampleRate(t *testing.T) {
+	client := &Client{}
+	err := client.SetSampleRate(0.2)
+
+	if err != nil {
+		t.Error("invalid sample rate")
+	}
+
+	if client.sampleRate != 0.2 {
+		t.Error("incorrect sample rate: ", client.sampleRate)
+	}
+}
+
+func TestSetSampleRateInvalid(t *testing.T) {
+	client := &Client{}
+	err := client.SetSampleRate(-1.0)
+
+	if err != ErrInvalidSampleRate {
+		t.Error("invalid sample rate should return ErrInvalidSampleRate")
+	}
+}
+
 func TestUnmarshalTag(t *testing.T) {
 	actual := new(Tag)
 	if err := json.Unmarshal([]byte(`["foo","bar"]`), actual); err != nil {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,23 @@ as the second argument. For example:
 
 Tags in Sentry help to categories and give you more information about the errors that happened.
 
+Event Sampling
+--------------------
+
+To setup client side sampling you can use ``SetSampleRate`` Client function.
+Error sampling is disabled by default (sampleRate=1).
+
+.. sourcecode:: go
+
+    package main
+
+    import "github.com/getsentry/raven-go"
+
+    func init() {
+        raven.SetSampleRate(0.25)
+    }
+
+
 Deep Dive
 ---------
 


### PR DESCRIPTION
Allow client side sampling setting sampleRate parameter in Client. This feature is really needed due to new changes in pricing and overquotas.

Default value is 1 (no sampling) 
To set sampling at 20% do `client.SetSampleRate(0.2)` 

Other sentry libraries with client sampling support:
* Python https://docs.sentry.io/clients/python/api/#client 
* Javascript https://docs.sentry.io/clients/javascript/config/#optional-settings