### PR TITLE
Integration with github.com/pkg/errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/certifi/gocertifi"
+	pkgErrors "github.com/pkg/errors"
 )
 
 const (
@@ -639,7 +640,9 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 		return ""
 	}
 
-	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, GetOrNewStacktrace(err, 1, 3, client.includePaths)))...)
+	cause := pkgErrors.Cause(err)
+
+	packet := NewPacket(cause.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(err, 1, 3, client.includePaths)))...)
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID

--- a/client.go
+++ b/client.go
@@ -639,7 +639,7 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 		return ""
 	}
 
-	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, NewStacktrace(1, 3, client.includePaths)))...)
+	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, GetOrNewStacktrace(err, 1, 3, client.includePaths)))...)
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID

--- a/http.go
+++ b/http.go
@@ -73,7 +73,7 @@ func RecoveryHandler(handler func(http.ResponseWriter, *http.Request)) func(http
 			if rval := recover(); rval != nil {
 				debug.PrintStack()
 				rvalStr := fmt.Sprint(rval)
-				packet := NewPacket(rvalStr, NewException(errors.New(rvalStr), NewStacktrace(2, 3, nil)), NewHttp(r))
+				packet := NewPacket(rvalStr, NewException(errors.New(rvalStr), GetOrNewStacktrace(rval.(error), 2, 3, nil)), NewHttp(r))
 				Capture(packet, nil)
 				w.WriteHeader(http.StatusInternalServerError)
 			}


### PR DESCRIPTION
First commit is squashed from https://github.com/pkg/errors

Second commit uses errors.Cause when passing in the error so we get the actual error struct instead of errors.withStack