### PR TITLE
Use cause in place of err in GetOrNewStacktrace

### DIFF
--- a/client.go
+++ b/client.go
@@ -318,7 +318,7 @@ func newTransport() Transport {
 	} else {
 		t.Client = &http.Client{
 			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
+				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: rootCAs},
 			},
 		}
@@ -642,7 +642,7 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 
 	cause := pkgErrors.Cause(err)
 
-	packet := NewPacket(cause.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(err, 1, 3, client.includePaths)))...)
+	packet := NewPacket(cause.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID
@@ -664,7 +664,9 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 		return ""
 	}
 
-	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(err, NewStacktrace(1, 3, client.includePaths)))...)
+	cause := pkgErrors.Cause(err)
+
+	packet := NewPacket(cause.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, ch := client.Capture(packet, tags)
 	<-ch
 


### PR DESCRIPTION
Many thanks to @jsm and @mattrobenolt for getting the pkg/errors integration piece merged in https://github.com/getsentry/raven-go/pull/152!

This PR fixes an issue where the cause wasn't actually being passed into `GetOrNewStacktrace`, meaning the generated stacktrace was of the last wrapped error rather than the originating one.

This PR also adds the integration into the `CaptureErrorAndWait` method in addition to the current `CaptureError`.

