### PR TITLE
Capture and CaptureError not to panic when packet or err is nil

### DIFF
--- a/client.go
+++ b/client.go
@@ -543,6 +543,11 @@ func (client *Client) Capture(packet *Packet, captureTags map[string]string) (ev
 		return
 	}
 
+	if packet == nil {
+		close(ch)
+		return
+	}
+
 	if client.shouldExcludeErr(packet.Message) {
 		return
 	}
@@ -658,6 +663,10 @@ func CaptureMessageAndWait(message string, tags map[string]string, interfaces ..
 // Adds a stacktrace to the packet, excluding the call to this method.
 func (client *Client) CaptureError(err error, tags map[string]string, interfaces ...Interface) string {
 	if client == nil {
+		return ""
+	}
+
+	if err == nil {
 		return ""
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -255,3 +255,24 @@ func TestNilClient(t *testing.T) {
                 t.Error("expected nil err:", err)
         }
 }
+
+func TestCaptureNil(t *testing.T) {
+        var client *Client = DefaultClient
+        eventID, ch := client.Capture(nil, nil)
+        if eventID != "" {
+                t.Error("expected empty eventID:", eventID)
+        }
+        // wait on ch: no send should succeed immediately
+        err := <-ch
+        if err != nil {
+                t.Error("expected nil err:", err)
+        }
+}
+
+func TestCaptureNilError(t *testing.T) {
+        var client *Client = DefaultClient
+        eventID := client.CaptureError(nil, nil)
+        if eventID != "" {
+                t.Error("expected empty eventID:", eventID)
+        }
+}


### PR DESCRIPTION
Capture methods can handle situations when client is nil, but when
packet or err args are nil it will cause calling thread to panic.
This is highly undesirable in PROD systems that accidentally try to log
a nil packet or error as it might cause a system crash on something
not produciton critical as error logging.