### PR TITLE
Use relative path in git submodule to bypass errors when fetch repos in docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_sentryext"]
 	path = docs/_sentryext
-	url = https://github.com/getsentry/sentry-doc-support
+	url = ../../getsentry/sentry-doc-support


### PR DESCRIPTION
When fetch repos in docker, we would get

```
[ERROR]	Failed to set version on github.com/getsentry/raven-go to 32a13797442ccb601b11761d74232773c1402d14: Unable to update checked out version: exit status 128
```

It is because we copy cached repos from host into docker. And in docker, if the git submodule ref to an absolute path, it would fail since that path would not exist in the docker container. 