### PR TITLE
Allow Packet.Release and Packet.Environment to be set manually

### DIFF
--- a/client.go
+++ b/client.go
@@ -582,8 +582,13 @@ func (client *Client) Capture(packet *Packet, captureTags map[string]string) (ev
 		return
 	}
 
-	packet.Release = release
-	packet.Environment = environment
+	if packet.Release == "" {
+		packet.Release = release
+	}
+
+	if packet.Environment == "" {
+		packet.Environment = environment
+	}
 
 	outgoingPacket := &outgoingPacket{packet, ch}
 


### PR DESCRIPTION
This adds a simple check to only overwrite the Packet's fields with Client settings when the fields are blank. It enables use cases where one Client is used to report errors from multiple applications, such as in logging and monitoring agents.