### PR TITLE
Capture extra info using interface{ExtraInfo() map[string]interface{}}

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,25 @@
+package raven
+
+type errWrappedWithExtra struct {
+	err       error
+	extraInfo map[string]interface{}
+}
+
+func (ewx *errWrappedWithExtra) Error() string {
+	return ewx.err.Error()
+}
+
+func (ewx *errWrappedWithExtra) Source() error {
+	return ewx.err
+}
+
+func (ewx *errWrappedWithExtra) ExtraInfo() Extra {
+	return ewx.extraInfo
+}
+
+func WrapWithExtra(err error, extraInfo map[string]interface{}) error {
+	return &errWrappedWithExtra{
+		err:       err,
+		extraInfo: extraInfo,
+	}
+}


### PR DESCRIPTION
# Goal
Surface a way to be able to capture extra information

## Related Issues
https://github.com/getsentry/raven-go/pull/134
https://github.com/getsentry/raven-go/pull/138
https://github.com/getsentry/raven-go/pull/146

## How is this different?
- Instead of changing the API, which would be a considerable change, use an interface on error and provide a function to wrap the error with extra information. 
- Allows setting extra information at the source, rather than having to manually do it wherever it's handled. It can be hard to pass the information needed up to the handler
- Works even wrapped with github.com/pkg/errors

## Public API Changes
```
raven.WrapWithExtra(err error, extraInfo map[string]interface{}) error
raven.NewPacketWithExtra(message string, extra Extra, interfaces ...Interface) *Packet

type Extra map[string]interface{}

type ErrWithExtra interface {
	Error() string
	Cause() error
	ExtraInfo() Extra
}
```