### PR TITLE
Print header x-sentry-error for more details

### DIFF
--- a/client.go
+++ b/client.go
@@ -916,7 +916,7 @@ func (t *HTTPTransport) Send(url, authHeader string, packet *Packet) error {
 	io.Copy(ioutil.Discard, res.Body)
 	res.Body.Close()
 	if res.StatusCode != 200 {
-		return fmt.Errorf("raven: got http status %d", res.StatusCode)
+		return fmt.Errorf("raven: got http status %d - x-sentry-error: %s", res.StatusCode, res.Header.Get("X-Sentry-Error"))
 	}
 	return nil
 }


### PR DESCRIPTION
## Context

If the http client gets an `http status != 200` in the sentry's response, header `x-sentry-error` might contain useful information that can help debugging. 

## Changes

- Get header `x-sentry-error` along with the http status code.