### PR TITLE
Add support for SENTRY_RELEASE and SENTRY_ENVIRONMENT envvars.

### DIFF
--- a/client.go
+++ b/client.go
@@ -337,6 +337,8 @@ func newClient(tags map[string]string) *Client {
 		queue:      make(chan *outgoingPacket, MaxQueueBuffer),
 	}
 	client.SetDSN(os.Getenv("SENTRY_DSN"))
+	client.SetRelease(os.Getenv("SENTRY_RELEASE"))
+	client.SetEnvironment(os.Getenv("SENTRY_ENVIRONMENT"))
 	return client
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,8 @@ Configuring the Client
 
 To use ``raven-go``, you'll need to import the ``raven`` package, then initilize your
 DSN globally. If you specify the ``SENTRY_DSN`` environment variable, this will be
-done automatically for you.
+done automatically for you. The release and environment can also be specified in the
+environment variables ``SENTRY_RELEASE`` and ``SENTRY_ENVIRONMENT`` respectively.
 
 .. sourcecode:: go
 

--- a/docs/integrations/http.rst
+++ b/docs/integrations/http.rst
@@ -28,7 +28,8 @@ in your ``main`` package is a good place.
     }
 
 If you don't call ``SetDSN``, we will attempt to read it from your environment under the
-``SENTRY_DSN`` environment variable.
+``SENTRY_DSN`` environment variable. The release and environment will also be read from
+the environment variables ``SENTRY_RELEASE`` and ``SENTRY_ENVIRONMENT`` if set.
 
 Next, we need to wrap our ``http.Handler`` with our ``RecoveryHandler``:
 


### PR DESCRIPTION
The Node client supports the environment variables, `SENTRY_RELEASE`, and `SENTRY_ENVIRONMENT`. The latter is particularly useful for specifying the app environment in e.g. Kubernetes manifests.

This patch adds support for these environment variables in the Go client as well.