### PR TITLE
Pass full error context to sentry

### DIFF
--- a/client.go
+++ b/client.go
@@ -681,7 +681,7 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 
 	cause := pkgErrors.Cause(err)
 
-	packet := NewPacket(cause.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
+	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID
@@ -705,7 +705,7 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 
 	cause := pkgErrors.Cause(err)
 
-	packet := NewPacket(cause.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
+	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, ch := client.Capture(packet, tags)
 	if eventID != "" {
 		<-ch


### PR DESCRIPTION
Currently the inner cause error is extracted to provide sentry with a stacktrace.
This potentially wrapped error does not have useful wrapped error messaging giving
context to the error and the code using it.

This change passes the error text from the original error rather than the wrapped
cause.

Resolves #176 