### PR TITLE
use runtime.Callers + runtime.CallersFrames

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -94,7 +94,7 @@ func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktra
 	var frames []*StacktraceFrame
 
 	callerPcs := make([]uintptr, 100)
-	numCallers := runtime.Callers(skip, callerPcs)
+	numCallers := runtime.Callers(skip+2, callerPcs)
 
 	// If there are no callers, the entire stacktrace is nil
 	if numCallers == 0 {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -61,14 +61,17 @@ func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []s
 		for _, f := range stacktracer.StackTrace() {
 			pc := uintptr(f) - 1
 			fn := runtime.FuncForPC(pc)
+			var fName string
 			var file string
 			var line int
 			if fn != nil {
 				file, line = fn.FileLine(pc)
+				fName = fn.Name()
 			} else {
 				file = "unknown"
+				fName = "unknown"
 			}
-			frame := NewStacktraceFrame(pc, file, line, context, appPackagePrefixes)
+			frame := NewStacktraceFrame(pc, fName, file, line, context, appPackagePrefixes)
 			if frame != nil {
 				frames = append([]*StacktraceFrame{frame}, frames...)
 			}
@@ -89,14 +92,27 @@ func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []s
 // be considered "in app".
 func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktrace {
 	var frames []*StacktraceFrame
-	for i := 1 + skip; ; i++ {
-		pc, file, line, ok := runtime.Caller(i)
-		if !ok {
-			break
+
+	callerPcs := make([]uintptr, 100)
+	numCallers := runtime.Callers(skip, callerPcs)
+
+	// If there are no callers, the entire stacktrace is nil
+	if numCallers == 0 {
+		return nil
+	}
+
+	callersFrames := runtime.CallersFrames(callerPcs)
+
+	for {
+		fr, more := callersFrames.Next()
+		if fr.Func != nil {
+			frame := NewStacktraceFrame(fr.PC, fr.Function, fr.File, fr.Line, context, appPackagePrefixes)
+			if frame != nil {
+				frames = append(frames, frame)
+			}
 		}
-		frame := NewStacktraceFrame(pc, file, line, context, appPackagePrefixes)
-		if frame != nil {
-			frames = append(frames, frame)
+		if !more {
+			break
 		}
 	}
 	// If there are no frames, the entire stacktrace is nil
@@ -122,9 +138,9 @@ func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktra
 //
 // appPackagePrefixes is a list of prefixes used to check whether a package should
 // be considered "in app".
-func NewStacktraceFrame(pc uintptr, file string, line, context int, appPackagePrefixes []string) *StacktraceFrame {
+func NewStacktraceFrame(pc uintptr, fName, file string, line, context int, appPackagePrefixes []string) *StacktraceFrame {
 	frame := &StacktraceFrame{AbsolutePath: file, Filename: trimPath(file), Lineno: line, InApp: false}
-	frame.Module, frame.Function = functionName(pc)
+	frame.Module, frame.Function = functionName(fName)
 
 	// `runtime.goexit` is effectively a placeholder that comes from
 	// runtime/asm_amd64.s and is meaningless.
@@ -166,12 +182,8 @@ func NewStacktraceFrame(pc uintptr, file string, line, context int, appPackagePr
 }
 
 // Retrieve the name of the package and function containing the PC.
-func functionName(pc uintptr) (pack string, name string) {
-	fn := runtime.FuncForPC(pc)
-	if fn == nil {
-		return
-	}
-	name = fn.Name()
+func functionName(fName string) (pack string, name string) {
+	name = fName
 	// We get this:
 	//	runtime/debug.*T·ptrmethod
 	// and want this:

--- a/stacktrace17.go
+++ b/stacktrace17.go
@@ -1,4 +1,4 @@
-// +build !go1.7
+// +build go1.7
 
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
@@ -63,14 +63,17 @@ func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []s
 		for _, f := range stacktracer.StackTrace() {
 			pc := uintptr(f) - 1
 			fn := runtime.FuncForPC(pc)
+			var fName string
 			var file string
 			var line int
 			if fn != nil {
 				file, line = fn.FileLine(pc)
+				fName = fn.Name()
 			} else {
 				file = "unknown"
+				fName = "unknown"
 			}
-			frame := NewStacktraceFrame(pc, file, line, context, appPackagePrefixes)
+			frame := NewStacktraceFrame(pc, fName, file, line, context, appPackagePrefixes)
 			if frame != nil {
 				frames = append([]*StacktraceFrame{frame}, frames...)
 			}
@@ -91,14 +94,27 @@ func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []s
 // be considered "in app".
 func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktrace {
 	var frames []*StacktraceFrame
-	for i := 1 + skip; ; i++ {
-		pc, file, line, ok := runtime.Caller(i)
-		if !ok {
-			break
+
+	callerPcs := make([]uintptr, 100)
+	numCallers := runtime.Callers(skip+2, callerPcs)
+
+	// If there are no callers, the entire stacktrace is nil
+	if numCallers == 0 {
+		return nil
+	}
+
+	callersFrames := runtime.CallersFrames(callerPcs)
+
+	for {
+		fr, more := callersFrames.Next()
+		if fr.Func != nil {
+			frame := NewStacktraceFrame(fr.PC, fr.Function, fr.File, fr.Line, context, appPackagePrefixes)
+			if frame != nil {
+				frames = append(frames, frame)
+			}
 		}
-		frame := NewStacktraceFrame(pc, file, line, context, appPackagePrefixes)
-		if frame != nil {
-			frames = append(frames, frame)
+		if !more {
+			break
 		}
 	}
 	// If there are no frames, the entire stacktrace is nil
@@ -124,9 +140,9 @@ func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktra
 //
 // appPackagePrefixes is a list of prefixes used to check whether a package should
 // be considered "in app".
-func NewStacktraceFrame(pc uintptr, file string, line, context int, appPackagePrefixes []string) *StacktraceFrame {
+func NewStacktraceFrame(pc uintptr, fName, file string, line, context int, appPackagePrefixes []string) *StacktraceFrame {
 	frame := &StacktraceFrame{AbsolutePath: file, Filename: trimPath(file), Lineno: line, InApp: false}
-	frame.Module, frame.Function = functionName(pc)
+	frame.Module, frame.Function = functionName(fName)
 
 	// `runtime.goexit` is effectively a placeholder that comes from
 	// runtime/asm_amd64.s and is meaningless.
@@ -168,12 +184,8 @@ func NewStacktraceFrame(pc uintptr, file string, line, context int, appPackagePr
 }
 
 // Retrieve the name of the package and function containing the PC.
-func functionName(pc uintptr) (pack string, name string) {
-	fn := runtime.FuncForPC(pc)
-	if fn == nil {
-		return
-	}
-	name = fn.Name()
+func functionName(fName string) (pack string, name string) {
+	name = fName
 	// We get this:
 	//	runtime/debug.*T·ptrmethod
 	// and want this:

--- a/stacktrace17_test.go
+++ b/stacktrace17_test.go
@@ -1,4 +1,4 @@
-// +build !go1.7
+// +build go1.7
 
 package raven
 
@@ -28,7 +28,8 @@ var (
 func TestFunctionName(t *testing.T) {
 	for _, test := range functionNameTests {
 		pc, _, _, _ := runtime.Caller(test.skip)
-		pack, name := functionName(pc)
+		fName := runtime.FuncForPC(pc).Name()
+		pack, name := functionName(fName)
 
 		if pack != test.pack {
 			t.Errorf("incorrect package; got %s, want %s", pack, test.pack)
@@ -61,7 +62,7 @@ func TestStacktrace(t *testing.T) {
 	if f.Module != thisPackage {
 		t.Error("incorrect Module:", f.Module)
 	}
-	if f.Lineno != 89 {
+	if f.Lineno != 90 {
 		t.Error("incorrect Lineno:", f.Lineno)
 	}
 	if f.ContextLine != "\treturn NewStacktrace(0, 2, []string{thisPackage})" {
@@ -124,7 +125,6 @@ func init() {
 		{0, thisPackage, "TestFunctionName"},
 		{1, "testing", "tRunner"},
 		{2, "runtime", "goexit"},
-		{100, "", ""},
 	}
 }
 

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -26,7 +26,8 @@ var (
 func TestFunctionName(t *testing.T) {
 	for _, test := range functionNameTests {
 		pc, _, _, _ := runtime.Caller(test.skip)
-		pack, name := functionName(pc)
+		fName := runtime.FuncForPC(pc).Name()
+		pack, name := functionName(fName)
 
 		if pack != test.pack {
 			t.Errorf("incorrect package; got %s, want %s", pack, test.pack)
@@ -122,7 +123,6 @@ func init() {
 		{0, thisPackage, "TestFunctionName"},
 		{1, "testing", "tRunner"},
 		{2, "runtime", "goexit"},
-		{100, "", ""},
 	}
 }
 

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -60,7 +60,7 @@ func TestStacktrace(t *testing.T) {
 	if f.Module != thisPackage {
 		t.Error("incorrect Module:", f.Module)
 	}
-	if f.Lineno != 87 {
+	if f.Lineno != 88 {
 		t.Error("incorrect Lineno:", f.Lineno)
 	}
 	if f.ContextLine != "\treturn NewStacktrace(0, 2, []string{thisPackage})" {


### PR DESCRIPTION
Go's `runtime` package includes [this comment](https://golang.org/src/runtime/extern.go?s=10177:10217#L205) about not using PCs directly:

```
// To translate these PCs into symbolic information such as function
// names and line numbers, use CallersFrames. CallersFrames accounts
// for inlined functions and adjusts the return program counters into
// call program counters. Iterating over the returned slice of PCs
// directly is discouraged, as is using FuncForPC on any of the
// returned PCs, since these cannot account for inlining or return
// program counter adjustment.
```

Convert `NewStacktrace`  over to using `runtime.Callers` and `runtime.CallersFrames` instead of looping over PCs.  Fixes #186 
