### PR TITLE
With extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
   - tip
 
 before_install:

--- a/client.go
+++ b/client.go
@@ -194,11 +194,12 @@ func NewPacketWithExtra(message string, extra Extra, interfaces ...Interface) *P
 	}
 }
 
-func setExtraDefaults(extra Extra) {
+func setExtraDefaults(extra Extra) Extra {
 	extra["runtime.Version"] = runtime.Version()
 	extra["runtime.NumCPU"] = runtime.NumCPU()
 	extra["runtime.GOMAXPROCS"] = runtime.GOMAXPROCS(0) // 0 just returns the current value
 	extra["runtime.NumGoroutine"] = runtime.NumGoroutine()
+	return extra
 }
 
 // Init initializes required fields in a packet. It is typically called by

--- a/client.go
+++ b/client.go
@@ -83,6 +83,8 @@ type Transport interface {
 	Send(url, authHeader string, packet *Packet) error
 }
 
+type Extra map[string]interface{}
+
 type outgoingPacket struct {
 	packet *Packet
 	ch     chan error
@@ -149,32 +151,49 @@ type Packet struct {
 	Logger    string    `json:"logger"`
 
 	// Optional
-	Platform    string                 `json:"platform,omitempty"`
-	Culprit     string                 `json:"culprit,omitempty"`
-	ServerName  string                 `json:"server_name,omitempty"`
-	Release     string                 `json:"release,omitempty"`
-	Environment string                 `json:"environment,omitempty"`
-	Tags        Tags                   `json:"tags,omitempty"`
-	Modules     map[string]string      `json:"modules,omitempty"`
-	Fingerprint []string               `json:"fingerprint,omitempty"`
-	Extra       map[string]interface{} `json:"extra,omitempty"`
+	Platform    string            `json:"platform,omitempty"`
+	Culprit     string            `json:"culprit,omitempty"`
+	ServerName  string            `json:"server_name,omitempty"`
+	Release     string            `json:"release,omitempty"`
+	Environment string            `json:"environment,omitempty"`
+	Tags        Tags              `json:"tags,omitempty"`
+	Modules     map[string]string `json:"modules,omitempty"`
+	Fingerprint []string          `json:"fingerprint,omitempty"`
+	Extra       Extra             `json:"extra,omitempty"`
 
 	Interfaces []Interface `json:"-"`
 }
 
 // NewPacket constructs a packet with the specified message and interfaces.
 func NewPacket(message string, interfaces ...Interface) *Packet {
-	extra := map[string]interface{}{
-		"runtime.Version":      runtime.Version(),
-		"runtime.NumCPU":       runtime.NumCPU(),
-		"runtime.GOMAXPROCS":   runtime.GOMAXPROCS(0), // 0 just returns the current value
-		"runtime.NumGoroutine": runtime.NumGoroutine(),
-	}
+	extra := Extra{}
+	setExtraDefaults(extra)
 	return &Packet{
 		Message:    message,
 		Interfaces: interfaces,
 		Extra:      extra,
 	}
+}
+
+// NewPacketWithExtra constructs a packet with the specified message, extra information, and interfaces.
+func NewPacketWithExtra(message string, extra Extra, interfaces ...Interface) *Packet {
+	if extra == nil {
+		extra = Extra{}
+	}
+	setExtraDefaults(extra)
+
+	return &Packet{
+		Message:    message,
+		Interfaces: interfaces,
+		Extra:      extra,
+	}
+}
+
+func setExtraDefaults(extra Extra) {
+	extra["runtime.Version"] = runtime.Version()
+	extra["runtime.NumCPU"] = runtime.NumCPU()
+	extra["runtime.GOMAXPROCS"] = runtime.GOMAXPROCS(0) // 0 just returns the current value
+	extra["runtime.NumGoroutine"] = runtime.NumGoroutine()
 }
 
 // Init initializes required fields in a packet. It is typically called by
@@ -681,9 +700,10 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 		return ""
 	}
 
+	extra := extractExtra(err)
 	cause := pkgErrors.Cause(err)
 
-	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
+	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID
@@ -705,9 +725,10 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 		return ""
 	}
 
+	extra := extractExtra(err)
 	cause := pkgErrors.Cause(err)
 
-	packet := NewPacket(err.Error(), append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
+	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, ch := client.Capture(packet, tags)
 	if eventID != "" {
 		<-ch

--- a/client.go
+++ b/client.go
@@ -68,6 +68,11 @@ func (timestamp *Timestamp) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (timestamp Timestamp) Format(format string) string {
+	t := time.Time(timestamp)
+	return t.Format(format)
+}
+
 // An Interface is a Sentry interface that will be serialized as JSON.
 // It must implement json.Marshaler or use json struct tags.
 type Interface interface {

--- a/client_test.go
+++ b/client_test.go
@@ -118,7 +118,7 @@ func TestPacketInit(t *testing.T) {
 		t.Errorf("ServerName should not be empty")
 	}
 	if packet.Level != ERROR {
-		t.Errorf("incorrect Level: got %d, want %d", packet.Level, ERROR)
+		t.Errorf("incorrect Level: got %s, want %s", packet.Level, ERROR)
 	}
 	if packet.Logger != "root" {
 		t.Errorf("incorrect Logger: got %s, want %s", packet.Logger, "root")
@@ -239,7 +239,7 @@ func TestUnmarshalTimestamp(t *testing.T) {
 	}
 
 	if actual != expected {
-		t.Errorf("incorrect string; got %s, want %s", actual, expected)
+		t.Errorf("incorrect string; got %s, want %s", actual.Format("2006-01-02 15:04:05 -0700"), expected.Format("2006-01-02 15:04:05 -0700"))
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -276,3 +276,44 @@ func TestCaptureNilError(t *testing.T) {
 		t.Error("expected empty eventID:", eventID)
 	}
 }
+
+func TestNewPacketWithExtraSetsDefault(t *testing.T) {
+	testCases := []struct {
+		Extra    Extra
+		Expected Extra
+	}{
+		// Defaults should be set when nil is passed
+		{
+			Extra:    nil,
+			Expected: setExtraDefaults(Extra{}),
+		},
+		// Defaults should be set when empty is passed
+		{
+			Extra:    Extra{},
+			Expected: setExtraDefaults(Extra{}),
+		},
+		// Packet should always override default keys
+		{
+			Extra: Extra{
+				"runtime.Version": "notagoversion",
+			},
+			Expected: setExtraDefaults(Extra{}),
+		},
+		// Packet should include our extra info
+		{
+			Extra: Extra{
+				"extra.extra": "extra",
+			},
+			Expected: setExtraDefaults(Extra{
+				"extra.extra": "extra",
+			}),
+		},
+	}
+
+	for i, test := range testCases {
+		packet := NewPacketWithExtra("packet", test.Extra)
+		if !reflect.DeepEqual(packet.Extra, test.Expected) {
+			t.Errorf("Case [%d]: Expected packet: %+v, got: %+v", i, test.Expected, packet.Extra)
+		}
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -1,13 +1,7 @@
 package raven
 
-import pkgErrors "github.com/pkg/errors"
-
 type causer interface {
 	Cause() error
-}
-
-type stacktracer interface {
-	StackTrace() pkgErrors.StackTrace
 }
 
 type errWrappedWithExtra struct {
@@ -27,6 +21,7 @@ func (ewx *errWrappedWithExtra) ExtraInfo() Extra {
 	return ewx.extraInfo
 }
 
+// Adds extra data to an error before reporting to Sentry
 func WrapWithExtra(err error, extraInfo map[string]interface{}) error {
 	return &errWrappedWithExtra{
 		err:       err,
@@ -40,6 +35,9 @@ type ErrWithExtra interface {
 	ExtraInfo() Extra
 }
 
+// Iteratively fetches all the Extra data added to an error,
+// and it's underlying errors. Extra data defined first is
+// respected, and is not overridden when extracting.
 func extractExtra(err error) Extra {
 	extra := Extra{}
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,62 @@
+package raven
+
+import pkgErrors "github.com/pkg/errors"
+
+type causer interface {
+	Cause() error
+}
+
+type stacktracer interface {
+	StackTrace() pkgErrors.StackTrace
+}
+
+type errWrappedWithExtra struct {
+	err       error
+	extraInfo map[string]interface{}
+}
+
+func (ewx *errWrappedWithExtra) Error() string {
+	return ewx.err.Error()
+}
+
+func (ewx *errWrappedWithExtra) Cause() error {
+	return ewx.err
+}
+
+func (ewx *errWrappedWithExtra) ExtraInfo() Extra {
+	return ewx.extraInfo
+}
+
+func WrapWithExtra(err error, extraInfo map[string]interface{}) error {
+	return &errWrappedWithExtra{
+		err:       err,
+		extraInfo: extraInfo,
+	}
+}
+
+type ErrWithExtra interface {
+	Error() string
+	Cause() error
+	ExtraInfo() Extra
+}
+
+func extractExtra(err error) Extra {
+	extra := Extra{}
+
+	currentErr := err
+	for currentErr != nil {
+		if errWithExtra, ok := currentErr.(ErrWithExtra); ok {
+			for k, v := range errWithExtra.ExtraInfo() {
+				extra[k] = v
+			}
+		}
+
+		if errWithCause, ok := currentErr.(causer); ok {
+			currentErr = errWithCause.Cause()
+		} else {
+			currentErr = nil
+		}
+	}
+
+	return extra
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,144 @@
+package raven
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	pkgErrors "github.com/pkg/errors"
+)
+
+func TestWrapWithExtraGeneratesProperErrWithExtra(t *testing.T) {
+	errMsg := "This is bad"
+	baseErr := fmt.Errorf(errMsg)
+	extraInfo := map[string]interface{}{
+		"string": "string",
+		"int":    1,
+		"float":  1.001,
+		"bool":   false,
+	}
+
+	testErr := WrapWithExtra(baseErr, extraInfo)
+	wrapped, ok := testErr.(ErrWithExtra)
+	if !ok {
+		t.Errorf("Wrapped error does not conform to expected protocol.")
+	}
+
+	if !reflect.DeepEqual(wrapped.Cause(), baseErr) {
+		t.Errorf("Failed to unwrap error, got %+v, expected %+v", wrapped.Cause(), baseErr)
+	}
+
+	returnedExtra := wrapped.ExtraInfo()
+	for expectedKey, expectedVal := range extraInfo {
+		val, ok := returnedExtra[expectedKey]
+		if !ok {
+			t.Errorf("Extra data missing key: %s", expectedKey)
+		}
+		if val != expectedVal {
+			t.Errorf("Extra data [%s]: Got: %+v, expected: %+v", expectedKey, val, expectedVal)
+		}
+	}
+
+	if wrapped.Error() != errMsg {
+		t.Errorf("Wrong error message, got: %q, expected: %q", wrapped.Error(), errMsg)
+	}
+}
+
+func TestWrapWithExtraGeneratesCausableError(t *testing.T) {
+	baseErr := fmt.Errorf("this is bad")
+	testErr := WrapWithExtra(baseErr, nil)
+	cause := pkgErrors.Cause(testErr)
+
+	if !reflect.DeepEqual(cause, baseErr) {
+		t.Errorf("Failed to unwrap error, got %+v, expected %+v", cause, baseErr)
+	}
+}
+
+func TestExtractErrorPullsExtraData(t *testing.T) {
+	extraInfo := map[string]interface{}{
+		"string": "string",
+		"int":    1,
+		"float":  1.001,
+		"bool":   false,
+	}
+	emptyInfo := map[string]interface{}{}
+
+	testCases := []struct {
+		Error    error
+		Expected map[string]interface{}
+	}{
+		// Unwrapped error shouldn't include anything
+		{
+			Error:    fmt.Errorf("This is bad"),
+			Expected: emptyInfo,
+		},
+		// Wrapped error with nil map should extract as empty info
+		{
+			Error:    WrapWithExtra(fmt.Errorf("This is bad"), nil),
+			Expected: emptyInfo,
+		},
+		// Wrapped error with empty map should extract as empty info
+		{
+			Error:    WrapWithExtra(fmt.Errorf("This is bad"), emptyInfo),
+			Expected: emptyInfo,
+		},
+		// Wrapped error with extra info should extract with all data
+		{
+			Error:    WrapWithExtra(fmt.Errorf("This is bad"), extraInfo),
+			Expected: extraInfo,
+		},
+		// Nested wrapped error should extract all the info
+		{
+			Error: WrapWithExtra(
+				WrapWithExtra(fmt.Errorf("This is bad"),
+					map[string]interface{}{
+						"inner": "123",
+					}),
+				map[string]interface{}{
+					"outer": "456",
+				},
+			),
+			Expected: map[string]interface{}{
+				"inner": "123",
+				"outer": "456",
+			},
+		},
+		// Futher wrapping of errors shouldn't allow for value override
+		{
+			Error: WrapWithExtra(
+				WrapWithExtra(fmt.Errorf("This is bad"),
+					map[string]interface{}{
+						"dontoverride": "123",
+					}),
+				map[string]interface{}{
+					"dontoverride": "456",
+				},
+			),
+			Expected: map[string]interface{}{
+				"dontoverride": "123",
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		extracted := extractExtra(test.Error)
+		if len(test.Expected) != len(extracted) {
+			t.Errorf(
+				"Case [%d]: Mismatched amount of data between provided and extracted extra. Got: %+v Expected: %+v",
+				i,
+				extracted,
+				test.Expected,
+			)
+		}
+
+		for expectedKey, expectedVal := range test.Expected {
+			val, ok := extracted[expectedKey]
+			if !ok {
+				t.Errorf("Case [%d]: Extra data missing key: %s", i, expectedKey)
+			}
+			if val != expectedVal {
+				t.Errorf("Case [%d]: Wrong extra data for %q. Got: %+v, expected: %+v", i, expectedKey, val, expectedVal)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hey there, I couldn't find a way to cleanly contribute this back, the original pr (#168) seems to have fallen off the radar.  I rebased this PR off the latest master, added tests and a couple comments to the original code.

The [first commit](https://github.com/getsentry/raven-go/commit/0180a7cda6e2ef481c6fe72434384f620583c8b8) I added fixes tests for go 1.10 (and ran gofmt over client_test.go unfortunately).  The actual relevant changes to look at are on lines [121](https://github.com/getsentry/raven-go/compare/master...JackWink:feature/with-extra?expand=1#diff-51565ad50d7426213c2f33579f6f0e71R121) and [242](https://github.com/getsentry/raven-go/compare/master...JackWink:feature/with-extra?expand=1#diff-51565ad50d7426213c2f33579f6f0e71R242). In short, fmt was failing to compile complaining that the string types (level) weren't integers (being formatted with %d) and then again on converting raven.Timestamp (time.Time) to a string.  There may be other/better ways to solve these issues that I'd be happy to address, I just wanted to get the tests in working order.

The second commit adds the test cases and comments. One thing I noticed was that errors that are double wrapped retain the earliest set value ie. there is no value overriding when wrapping again. I opted to note the behavior and not change it, but it should be easy to use the latest defined value if that's the desired behavior.