### PR TITLE
add raven.Recoverer(handler http.Handler) http.Handler

### DIFF
--- a/http.go
+++ b/http.go
@@ -69,7 +69,16 @@ func (h *Http) Class() string { return "request" }
 //		...
 //	}))
 func RecoveryHandler(handler func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return Recoverer(http.HandlerFunc(handler)).ServeHTTP
+}
+
+// Recovery handler to wrap the stdlib net/http Mux.
+// Example:
+//  mux := http.NewServeMux
+//  ...
+//	http.Handle("/", raven.Recoverer(mux))
+func Recoverer(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rval := recover(); rval != nil {
 				debug.PrintStack()
@@ -80,6 +89,6 @@ func RecoveryHandler(handler func(http.ResponseWriter, *http.Request)) func(http
 			}
 		}()
 
-		handler(w, r)
-	}
+		handler.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
This pr adds `raven.Recoverer` to complement `raven.RecoveryHandler`. The main difference is that `raven.Recoverer` takes an `http.Handler` and returns an `http.Handler`. This is a small difference, but it means that in frameworks such as [Chi](https://github.com/go-chi/chi), one can use raven as middleware:
```
r := chu.NewRouter()
r.Use(raven.Recoverer)
...
```
The original `raven.RecoveryHandler` remain unchanged

Fixes #182 