### PR TITLE
Custom sanitize fields. Sanitize headers.

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -141,8 +141,36 @@ func parseQuery(q string) url.Values {
 
 func TestSanitizeQuery(t *testing.T) {
 	for _, test := range sanitizeQueryTests {
-		actual := sanitizeQuery(parseQuery(test.input))
+		actual := url.Values(sanitizeValues(parseQuery(test.input)))
 		expected := parseQuery(test.output)
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("incorrect sanitization: got %+v, want %+v", actual, expected)
+		}
+	}
+}
+
+var sanitizeHeadersTest = []struct {
+	input, output string
+}{
+	{"foo=bar", "foo=bar"},
+	{"password=foo", "password=********"},
+	{"passphrase=foo", "passphrase=********"},
+	{"passwd=foo", "passwd=********"},
+	{"secret=foo", "secret=********"},
+	{"secretstuff=foo", "secretstuff=********"},
+	{"foo=bar&secret=foo", "foo=bar&secret=********"},
+	{"secret=foo&secret=bar", "secret=********"},
+}
+
+func parseHeaders(q string) http.Header {
+	r, _ := url.ParseQuery(q)
+	return http.Header(r)
+}
+
+func TestSanitizeHeaders(t *testing.T) {
+	for _, test := range sanitizeHeadersTest {
+		actual := http.Header(sanitizeValues(parseQuery(test.input)))
+		expected := parseHeaders(test.output)
 		if !reflect.DeepEqual(actual, expected) {
 			t.Errorf("incorrect sanitization: got %+v, want %+v", actual, expected)
 		}


### PR DESCRIPTION
We wanted to customize the fields being sanitized.

Example:

```
raven.AddSanitizeField("token")
```