### PR TITLE
docs: typo causing go.http doc_link to be null

### DIFF
--- a/docs/sentry-doc-config.json
+++ b/docs/sentry-doc-config.json
@@ -15,7 +15,7 @@
     "go.http": {
       "name": "net/http",
       "type": "framework",
-      "doc_wizard": "integrations/http/",
+      "doc_link": "integrations/http/",
       "wizard": [
         "integrations/http#installation",
         "integrations/http#setup"


### PR DESCRIPTION
I assume this is a typo. It's breaking the migrator.