### PR TITLE
Use pointer type for right use of mutex

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -195,7 +195,7 @@ type SourceCodeLoader interface {
 	Load(filename string, line, context int) ([][]byte, int)
 }
 
-var sourceCodeLoader SourceCodeLoader = fsLoader{cache: make(map[string][][]byte)}
+var sourceCodeLoader SourceCodeLoader = &fsLoader{cache: make(map[string][][]byte)}
 
 func SetSourceCodeLoader(loader SourceCodeLoader) {
 	sourceCodeLoader = loader
@@ -206,7 +206,7 @@ type fsLoader struct {
 	cache map[string][][]byte
 }
 
-func (fs fsLoader) Load(filename string, line, context int) ([][]byte, int) {
+func (fs *fsLoader) Load(filename string, line, context int) ([][]byte, int) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	lines, ok := fs.cache[filename]

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -169,7 +169,7 @@ func TestNewStacktrace_noFrames(t *testing.T) {
 
 func TestFileContext(t *testing.T) {
 	// reset the cache
-	sourceCodeLoader = fsLoader{cache: make(map[string][][]byte)}
+	sourceCodeLoader = &fsLoader{cache: make(map[string][][]byte)}
 
 	tempdir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -205,7 +205,7 @@ func TestFileContext(t *testing.T) {
 			t.Errorf("%d: fileContext(%#v, 1, 0) = %v, %v; expected len()=%d, %d",
 				i, test.path, lines, index, test.expectedLines, test.expectedIndex)
 		}
-		cacheLen := len(sourceCodeLoader.(fsLoader).cache)
+		cacheLen := len(sourceCodeLoader.(*fsLoader).cache)
 		if cacheLen != i+1 {
 			t.Errorf("%d: result was not cached; len=%d", i, cacheLen)
 		}


### PR DESCRIPTION
Hi, I found a bug in a default `SourceCodeLoader`.

`fsLoader` uses `sync.Mutex`, but its receiver type of `Load` is a value.
So `mu.Lock` and `mu.Unlock` does not affects shared state.
It causes race condition when writing `fsLoader.cache` from multiple goroutines.