### PR TITLE
stacktrace: unescape pack after splitting

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"go/build"
 	"io/ioutil"
+	"net/url"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -186,6 +187,10 @@ func splitFunctionName(name string) (string, string) {
 	if pos := strings.Index(name, "."); pos != -1 {
 		pack += name[:pos]
 		name = name[pos+1:]
+	}
+
+	if p, err := url.QueryUnescape(pack); err == nil {
+		pack = p
 	}
 
 	return pack, name

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -61,6 +61,7 @@ func TestSplitFunctionName(t *testing.T) {
 		{"cmd/main.main.func1.1.1", "cmd/main", "main.func1.1.1"},
 		{"cmd/main.(*T).Do", "cmd/main", "(*T).Do"},
 		{"cmd/main.*T.Do", "cmd/main", "*T.Do"},
+		{`github.com/getsentry/dot%2epackage.*T.Do`, "github.com/getsentry/dot.package", "*T.Do"},
 	}
 
 	for _, test := range tests {
@@ -93,7 +94,7 @@ func TestStacktrace(t *testing.T) {
 	if f.Module != thisPackage {
 		t.Error("incorrect Module:", f.Module)
 	}
-	if f.Lineno != 121 {
+	if f.Lineno != 122 {
 		t.Error("incorrect Lineno:", f.Lineno)
 	}
 	if f.ContextLine != "\treturn NewStacktrace(0, 2, []string{thisPackage})" {


### PR DESCRIPTION
This was part of #141 that "undo" the URL escaped package name so that it will be displayed prettier.

@dcramer, could you kindly have a look? Thanks!