### PR TITLE
Make raven-go a go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/getsentry/raven-go
+
+require (
+	github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2
+	github.com/pkg/errors v0.8.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2 h1:MmeatFT1pTPSVb4nkPmBFN/LRZ97vPjsFKsZrU3KKTs=
+github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Created `go.mod` and `go.sum` files to use raven-go as a [go module](https://github.com/golang/go/wiki/Modules).