### PR TITLE
add support for github.com/pingcap/errors stacktraces

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	pingcap "github.com/pingcap/errors"
 	"github.com/pkg/errors"
 )
 
@@ -51,32 +52,66 @@ type StacktraceFrame struct {
 	InApp        bool     `json:"in_app"`
 }
 
-// Try to get stacktrace from err as an interface of github.com/pkg/errors, or else NewStacktrace()
-func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []string) *Stacktrace {
-	stacktracer, errHasStacktrace := err.(interface {
-		StackTrace() errors.StackTrace
-	})
-	if errHasStacktrace {
-		var frames []*StacktraceFrame
-		for f := range stacktracer.StackTrace() {
-			pc := uintptr(f) - 1
-			fn := runtime.FuncForPC(pc)
-			var fName string
-			var file string
-			var line int
-			if fn != nil {
-				file, line = fn.FileLine(pc)
-				fName = fn.Name()
-			} else {
-				file = "unknown"
-				fName = "unknown"
-			}
-			frame := NewStacktraceFrame(pc, fName, file, line, context, appPackagePrefixes)
-			if frame != nil {
-				frames = append([]*StacktraceFrame{frame}, frames...)
-			}
+type pkgStacktracer interface {
+	StackTrace() errors.StackTrace
+}
+
+func pkgStacktrace(stacktracer pkgStacktracer, context int, appPackagePrefixes []string) *Stacktrace {
+	var frames []*StacktraceFrame
+	for f := range stacktracer.StackTrace() {
+		pc := uintptr(f) - 1
+		fn := runtime.FuncForPC(pc)
+		var fName string
+		var file string
+		var line int
+		if fn != nil {
+			file, line = fn.FileLine(pc)
+			fName = fn.Name()
+		} else {
+			file = "unknown"
+			fName = "unknown"
 		}
-		return &Stacktrace{Frames: frames}
+		frame := NewStacktraceFrame(pc, fName, file, line, context, appPackagePrefixes)
+		if frame != nil {
+			frames = append([]*StacktraceFrame{frame}, frames...)
+		}
+	}
+	return &Stacktrace{Frames: frames}
+}
+
+type pingcapStacktracer interface {
+	StackTrace() pingcap.StackTrace
+}
+
+func pingcapStacktrace(stacktracer pingcapStacktracer, context int, appPackagePrefixes []string) *Stacktrace {
+	var frames []*StacktraceFrame
+	for f := range stacktracer.StackTrace() {
+		pc := uintptr(f) - 1
+		fn := runtime.FuncForPC(pc)
+		var fName string
+		var file string
+		var line int
+		if fn != nil {
+			file, line = fn.FileLine(pc)
+			fName = fn.Name()
+		} else {
+			file = "unknown"
+			fName = "unknown"
+		}
+		frame := NewStacktraceFrame(pc, fName, file, line, context, appPackagePrefixes)
+		if frame != nil {
+			frames = append([]*StacktraceFrame{frame}, frames...)
+		}
+	}
+	return &Stacktrace{Frames: frames}
+}
+
+// Try to get stacktrace from err as an interface of github.com/pkg/errors or github.com/pingcap/errors, or else NewStacktrace()
+func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []string) *Stacktrace {
+	if stacktracer, errHasStacktrace := err.(pkgStacktracer); errHasStacktrace {
+		return pkgStacktrace(stacktracer, context, appPackagePrefixes)
+	} else if stacktracer, errHasStacktrace := err.(pingcapStacktracer); errHasStacktrace {
+		return pingcapStacktrace(stacktracer, context, appPackagePrefixes)
 	} else {
 		return NewStacktrace(skip+1, context, appPackagePrefixes)
 	}


### PR DESCRIPTION
PingCAP's errors package is a fork of pkg/errors that makes a few nice improvements, like being able to call `errors.AddStack(err)` several times at different levels of the call stack without overwriting any existing stacktrace, since it checks whether one is already associated with the error before capturing and storing a new one.

Their package is not as widely used as pkg/errors, but hopefully this patch is small enough to be merged in!