### PR TITLE
Remove reliance on pkg/errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/certifi/gocertifi"
-	pkgErrors "github.com/pkg/errors"
 )
 
 const (
@@ -707,7 +706,7 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 	}
 
 	extra := extractExtra(err)
-	cause := pkgErrors.Cause(err)
+	cause := Cause(err)
 
 	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, _ := client.Capture(packet, tags)
@@ -732,7 +731,7 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 	}
 
 	extra := extractExtra(err)
-	cause := pkgErrors.Cause(err)
+	cause := Cause(err)
 
 	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
 	eventID, ch := client.Capture(packet, tags)
@@ -974,4 +973,30 @@ var hostname string
 
 func init() {
 	hostname, _ = os.Hostname()
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-
-	pkgErrors "github.com/pkg/errors"
 )
 
 func TestWrapWithExtraGeneratesProperErrWithExtra(t *testing.T) {
@@ -47,7 +45,7 @@ func TestWrapWithExtraGeneratesProperErrWithExtra(t *testing.T) {
 func TestWrapWithExtraGeneratesCausableError(t *testing.T) {
 	baseErr := fmt.Errorf("this is bad")
 	testErr := WrapWithExtra(baseErr, nil)
-	cause := pkgErrors.Cause(testErr)
+	cause := Cause(testErr)
 
 	if !reflect.DeepEqual(cause, baseErr) {
 		t.Errorf("Failed to unwrap error, got %+v, expected %+v", cause, baseErr)


### PR DESCRIPTION
We don't actually use anything out of this library except talking with
it's interfaces, so let's abstract out usage rather than forcing a
strong dependency on the library.