### PR TITLE
Support extracting extra infromation from errors without Cause()

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -29,11 +29,16 @@ func WrapWithExtra(err error, extraInfo map[string]interface{}) error {
 	}
 }
 
+// errWithJustExtra is a regular error with just the user-provided extras added but without a cause
+type errWithJustExtra interface {
+	error
+	ExtraInfo() Extra
+}
+
 // ErrWithExtra links Error with attached user-provided extras that will be reported alongside the Error
 type ErrWithExtra interface {
-	Error() string
+	errWithJustExtra
 	Cause() error
-	ExtraInfo() Extra
 }
 
 // Iteratively fetches all the Extra data added to an error,
@@ -44,7 +49,7 @@ func extractExtra(err error) Extra {
 
 	currentErr := err
 	for currentErr != nil {
-		if errWithExtra, ok := currentErr.(ErrWithExtra); ok {
+		if errWithExtra, ok := currentErr.(errWithJustExtra); ok {
 			for k, v := range errWithExtra.ExtraInfo() {
 				extra[k] = v
 			}

--- a/errors_test.go
+++ b/errors_test.go
@@ -140,3 +140,19 @@ func TestExtractErrorPullsExtraData(t *testing.T) {
 		}
 	}
 }
+
+type errorWithJustExtra struct{}
+
+func (e *errorWithJustExtra) Error() string {
+	return "oops"
+}
+func (e *errorWithJustExtra) ExtraInfo() Extra {
+	return Extra{"foo": "bar"}
+}
+
+func TestExtractExtraDoesNotRequireCause(t *testing.T) {
+	extra := extractExtra(&errorWithJustExtra{})
+	if extra["foo"] != "bar" {
+		t.Error("Could not extract extra without cause")
+	}
+}


### PR DESCRIPTION
The current implementation of extractExtra() requires an interface containing both Cause() and ExtraInfo().
This means that no ExtraInfo() can be extracted from root causes..

I'm not 100% sure if this change is backwards compatible for lack of knowledge of Go but from all I know it should be.