### PR TITLE
Fix compatability with Go 1.12

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -106,11 +106,9 @@ func NewStacktrace(skip int, context int, appPackagePrefixes []string) *Stacktra
 
 	for {
 		fr, more := callersFrames.Next()
-		if fr.Func != nil {
-			frame := NewStacktraceFrame(fr.PC, fr.Function, fr.File, fr.Line, context, appPackagePrefixes)
-			if frame != nil {
-				frames = append(frames, frame)
-			}
+		frame := NewStacktraceFrame(fr.PC, fr.Function, fr.File, fr.Line, context, appPackagePrefixes)
+		if frame != nil {
+			frames = append(frames, frame)
 		}
 		if !more {
 			break


### PR DESCRIPTION
Go 1.12 has changed how it determines what functions can be in-lined.  This patch fixes raven-go to correctly handle when Go inlines a function in the stack.