### PR TITLE
Set default timeout for transport http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	userAgent       = "raven-go/1.0"
-	timestampFormat = `"2006-01-02T15:04:05.00"`
+	userAgent              = "raven-go/1.0"
+	timestampFormat        = `"2006-01-02T15:04:05.00"`
+	transportClientTimeout = 30 * time.Second
 )
 
 // Internal SDK Error types
@@ -364,6 +365,7 @@ func newTransport() Transport {
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{RootCAs: rootCAs},
 			},
+			Timeout: transportClientTimeout,
 		}
 	}
 	return t


### PR DESCRIPTION
By default, the `http.Client` has a Timeout of 0, which means no timeout (infinite long lived connection). this is source of hang in high latency environment but also can be source of memory leaks. I suggest adding a default timeout to avoid this. 