### PR TITLE
Return empty string if errWrappedWithExtra.err is nil

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,10 @@ type errWrappedWithExtra struct {
 }
 
 func (ewx *errWrappedWithExtra) Error() string {
+	if ewx.err == nil {
+		return ""
+	}
+
 	return ewx.err.Error()
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -156,3 +156,10 @@ func TestExtractExtraDoesNotRequireCause(t *testing.T) {
 		t.Error("Could not extract extra without cause")
 	}
 }
+
+func TestErrWrappedWithExtraWithNilError(t *testing.T) {
+	ewx := WrapWithExtra(nil, map[string]interface{}{})
+	if errString := ewx.Error(); errString != "" {
+		t.Errorf("Expected empty string got %s", errString)
+	}
+}


### PR DESCRIPTION
Calling `ewx.err.Error()` can result in a panic if err is nil.  This PR adds a fallback that returns an empty string if this ends up being the case.