### PR TITLE
Fix iteration bug in GetOrNewStackTrace()

### DIFF
--- a/stacktrace.go
+++ b/stacktrace.go
@@ -62,8 +62,8 @@ func GetOrNewStacktrace(err error, skip int, context int, appPackagePrefixes []s
 		return NewStacktrace(skip+1, context, appPackagePrefixes)
 	}
 	var frames []*StacktraceFrame
-	for f := range stacktrace.StackTrace() {
-		pc := uintptr(f) - 1
+	for _, f := range stacktrace.StackTrace() {
+		pc := uintptr(f.PC) - 1
 		fn := runtime.FuncForPC(pc)
 		var fName string
 		var file string


### PR DESCRIPTION
Fixes: https://github.com/getsentry/raven-go/issues/256
Update GetOrNewStackTrace() to iterate over stacktracer.StackTrace() elements