### PR TITLE
Add level/severity support

### DIFF
--- a/client.go
+++ b/client.go
@@ -698,6 +698,10 @@ func (client *Client) CaptureMessage(message string, tags map[string]string, int
 	}
 
 	packet := NewPacket(message, append(append(interfaces, client.context.interfaces()...), &Message{message, nil})...)
+	if tags["level"] != "" && Severity(tags["level"]) != ""{
+		packet.Level = Severity(tags["level"])
+	}
+
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID
@@ -719,6 +723,10 @@ func (client *Client) CaptureMessageAndWait(message string, tags map[string]stri
 	}
 
 	packet := NewPacket(message, append(append(interfaces, client.context.interfaces()...), &Message{message, nil})...)
+	if tags["level"] != "" && Severity(tags["level"]) != ""{
+		packet.Level = Severity(tags["level"])
+	}
+
 	eventID, ch := client.Capture(packet, tags)
 	if eventID != "" {
 		<-ch
@@ -751,6 +759,10 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 	cause := Cause(err)
 
 	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
+	if tags["level"] != "" && Severity(tags["level"]) != ""{
+		packet.Level = Severity(tags["level"])
+	}
+
 	eventID, _ := client.Capture(packet, tags)
 
 	return eventID
@@ -776,6 +788,10 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 	cause := Cause(err)
 
 	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
+	if tags["level"] != "" && Severity(tags["level"]) != ""{
+		packet.Level = Severity(tags["level"])
+	}
+
 	eventID, ch := client.Capture(packet, tags)
 	if eventID != "" {
 		<-ch
@@ -807,12 +823,18 @@ func (client *Client) CapturePanic(f func(), tags map[string]string, interfaces 
 				return
 			}
 			packet = NewPacket(rval.Error(), append(append(interfaces, client.context.interfaces()...), NewException(rval, NewStacktrace(2, 3, client.includePaths)))...)
+			if tags["level"] != "" && Severity(tags["level"]) != ""{
+				packet.Level = Severity(tags["level"])
+			}
 		default:
 			rvalStr := fmt.Sprint(rval)
 			if client.shouldExcludeErr(rvalStr) {
 				return
 			}
 			packet = NewPacket(rvalStr, append(append(interfaces, client.context.interfaces()...), NewException(errors.New(rvalStr), NewStacktrace(2, 3, client.includePaths)))...)
+			if tags["level"] != "" && Severity(tags["level"]) != ""{
+				packet.Level = Severity(tags["level"])
+			}
 		}
 
 		errorID, _ = client.Capture(packet, tags)
@@ -845,12 +867,18 @@ func (client *Client) CapturePanicAndWait(f func(), tags map[string]string, inte
 				return
 			}
 			packet = NewPacket(rval.Error(), append(append(interfaces, client.context.interfaces()...), NewException(rval, NewStacktrace(2, 3, client.includePaths)))...)
+			if tags["level"] != "" && Severity(tags["level"]) != ""{
+				packet.Level = Severity(tags["level"])
+			}
 		default:
 			rvalStr := fmt.Sprint(rval)
 			if client.shouldExcludeErr(rvalStr) {
 				return
 			}
 			packet = NewPacket(rvalStr, append(append(interfaces, client.context.interfaces()...), NewException(errors.New(rvalStr), NewStacktrace(2, 3, client.includePaths)))...)
+			if tags["level"] != "" && Severity(tags["level"]) != ""{
+				packet.Level = Severity(tags["level"])
+			}
 		}
 
 		var ch chan error

--- a/client.go
+++ b/client.go
@@ -219,6 +219,12 @@ func setExtraDefaults(extra Extra) Extra {
 	return extra
 }
 
+func setPacketLevel (packet *Packet, level string) {
+	if Severity(level) != "" {
+		packet.Level = Severity(level)
+	}
+}
+
 // Init initializes required fields in a packet. It is typically called by
 // Client.Send/Report automatically.
 func (packet *Packet) Init(project string) error {
@@ -698,9 +704,7 @@ func (client *Client) CaptureMessage(message string, tags map[string]string, int
 	}
 
 	packet := NewPacket(message, append(append(interfaces, client.context.interfaces()...), &Message{message, nil})...)
-	if tags["level"] != "" && Severity(tags["level"]) != ""{
-		packet.Level = Severity(tags["level"])
-	}
+	setPacketLevel(packet, tags["level"])
 
 	eventID, _ := client.Capture(packet, tags)
 
@@ -723,9 +727,7 @@ func (client *Client) CaptureMessageAndWait(message string, tags map[string]stri
 	}
 
 	packet := NewPacket(message, append(append(interfaces, client.context.interfaces()...), &Message{message, nil})...)
-	if tags["level"] != "" && Severity(tags["level"]) != ""{
-		packet.Level = Severity(tags["level"])
-	}
+	setPacketLevel(packet, tags["level"])
 
 	eventID, ch := client.Capture(packet, tags)
 	if eventID != "" {
@@ -759,9 +761,7 @@ func (client *Client) CaptureError(err error, tags map[string]string, interfaces
 	cause := Cause(err)
 
 	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
-	if tags["level"] != "" && Severity(tags["level"]) != ""{
-		packet.Level = Severity(tags["level"])
-	}
+	setPacketLevel(packet, tags["level"])
 
 	eventID, _ := client.Capture(packet, tags)
 
@@ -788,9 +788,7 @@ func (client *Client) CaptureErrorAndWait(err error, tags map[string]string, int
 	cause := Cause(err)
 
 	packet := NewPacketWithExtra(err.Error(), extra, append(append(interfaces, client.context.interfaces()...), NewException(cause, GetOrNewStacktrace(cause, 1, 3, client.includePaths)))...)
-	if tags["level"] != "" && Severity(tags["level"]) != ""{
-		packet.Level = Severity(tags["level"])
-	}
+	setPacketLevel(packet, tags["level"])
 
 	eventID, ch := client.Capture(packet, tags)
 	if eventID != "" {
@@ -823,18 +821,14 @@ func (client *Client) CapturePanic(f func(), tags map[string]string, interfaces 
 				return
 			}
 			packet = NewPacket(rval.Error(), append(append(interfaces, client.context.interfaces()...), NewException(rval, NewStacktrace(2, 3, client.includePaths)))...)
-			if tags["level"] != "" && Severity(tags["level"]) != ""{
-				packet.Level = Severity(tags["level"])
-			}
+			setPacketLevel(packet, tags["level"])
 		default:
 			rvalStr := fmt.Sprint(rval)
 			if client.shouldExcludeErr(rvalStr) {
 				return
 			}
 			packet = NewPacket(rvalStr, append(append(interfaces, client.context.interfaces()...), NewException(errors.New(rvalStr), NewStacktrace(2, 3, client.includePaths)))...)
-			if tags["level"] != "" && Severity(tags["level"]) != ""{
-				packet.Level = Severity(tags["level"])
-			}
+			setPacketLevel(packet, tags["level"])
 		}
 
 		errorID, _ = client.Capture(packet, tags)
@@ -867,18 +861,14 @@ func (client *Client) CapturePanicAndWait(f func(), tags map[string]string, inte
 				return
 			}
 			packet = NewPacket(rval.Error(), append(append(interfaces, client.context.interfaces()...), NewException(rval, NewStacktrace(2, 3, client.includePaths)))...)
-			if tags["level"] != "" && Severity(tags["level"]) != ""{
-				packet.Level = Severity(tags["level"])
-			}
+			setPacketLevel(packet, tags["level"])
 		default:
 			rvalStr := fmt.Sprint(rval)
 			if client.shouldExcludeErr(rvalStr) {
 				return
 			}
 			packet = NewPacket(rvalStr, append(append(interfaces, client.context.interfaces()...), NewException(errors.New(rvalStr), NewStacktrace(2, 3, client.includePaths)))...)
-			if tags["level"] != "" && Severity(tags["level"]) != ""{
-				packet.Level = Severity(tags["level"])
-			}
+			setPacketLevel(packet, tags["level"])
 		}
 
 		var ch chan error


### PR DESCRIPTION
Currently all sentry messages are ERROR level. To support "debug"/"info"/"warning"/"fatal", we can use tags parameter. Actually in Sentry UI panel, we can see "level" tag but the value is always "error" at this moment.

The change is backward compatible. If developer wants to use this new enhancement, here is an example:
```
raven.CaptureErrorAndWait(errors.New("Test1"),map[string]string{
    "level" : "warning",
})
```