### PR TITLE
fix: Panic when cause is nil while calling client.CaptureError

### DIFF
--- a/client.go
+++ b/client.go
@@ -1074,8 +1074,15 @@ func init() {
 //     }
 //
 // If the error does not implement Cause, the original error will
-// be returned. If the error is nil, nil will be returned without further
+// be returned.
+//
+// If the cause of the error is nil, then the original
+// error will be returned.
+//
+// If the error is nil, nil will be returned without further
 // investigation.
+//
+// Will return the deepest cause which is not nil.
 func Cause(err error) error {
 	type causer interface {
 		Cause() error
@@ -1086,7 +1093,13 @@ func Cause(err error) error {
 		if !ok {
 			break
 		}
-		err = cause.Cause()
+
+		if _cause := cause.Cause(); _cause != nil {
+			err = _cause
+		} else {
+			break
+		}
+
 	}
 	return err
 }


### PR DESCRIPTION
* Return deepest cause which is not nil
* Test if a nil cause results in a panic

Fixes [#260](https://github.com/getsentry/raven-go/issues/260)